### PR TITLE
Epic 2: Transactions - Full Implementation

### DIFF
--- a/backend/src/main/java/com/pfwa/config/AppProperties.java
+++ b/backend/src/main/java/com/pfwa/config/AppProperties.java
@@ -93,6 +93,8 @@ public class AppProperties {
         private int maxFailedLoginAttempts = 5;
         private int accountLockoutMinutes = 30;
         private int maxSessionsPerUser = 5;
+        private boolean secureCookies = true;
+        private String cookieSameSite = "Strict";
 
         public int getBcryptStrength() {
             return bcryptStrength;
@@ -124,6 +126,22 @@ public class AppProperties {
 
         public void setMaxSessionsPerUser(int maxSessionsPerUser) {
             this.maxSessionsPerUser = maxSessionsPerUser;
+        }
+
+        public boolean isSecureCookies() {
+            return secureCookies;
+        }
+
+        public void setSecureCookies(boolean secureCookies) {
+            this.secureCookies = secureCookies;
+        }
+
+        public String getCookieSameSite() {
+            return cookieSameSite;
+        }
+
+        public void setCookieSameSite(String cookieSameSite) {
+            this.cookieSameSite = cookieSameSite;
         }
     }
 

--- a/backend/src/main/java/com/pfwa/controller/AuthController.java
+++ b/backend/src/main/java/com/pfwa/controller/AuthController.java
@@ -250,10 +250,13 @@ public class AuthController {
      * Sets the access token as an HttpOnly cookie.
      */
     private void setAccessTokenCookie(HttpServletResponse response, String token) {
+        boolean secure = appProperties.getSecurity().isSecureCookies();
+        String sameSite = appProperties.getSecurity().getCookieSameSite();
+
         ResponseCookie cookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE, token)
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
+                .secure(secure)
+                .sameSite(sameSite)
                 .path("/")
                 .maxAge(Duration.ofMinutes(appProperties.getJwt().getAccessTokenExpirationMinutes()))
                 .build();
@@ -269,10 +272,13 @@ public class AuthController {
                 appProperties.getJwt().getRefreshTokenRememberMeDays() :
                 appProperties.getJwt().getRefreshTokenExpirationDays();
 
+        boolean secure = appProperties.getSecurity().isSecureCookies();
+        String sameSite = appProperties.getSecurity().getCookieSameSite();
+
         ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, token)
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
+                .secure(secure)
+                .sameSite(sameSite)
                 .path("/api/v1/auth")
                 .maxAge(Duration.ofDays(expirationDays))
                 .build();
@@ -284,18 +290,21 @@ public class AuthController {
      * Clears authentication cookies.
      */
     private void clearAuthCookies(HttpServletResponse response) {
+        boolean secure = appProperties.getSecurity().isSecureCookies();
+        String sameSite = appProperties.getSecurity().getCookieSameSite();
+
         ResponseCookie clearAccessToken = ResponseCookie.from(ACCESS_TOKEN_COOKIE, "")
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
+                .secure(secure)
+                .sameSite(sameSite)
                 .path("/")
                 .maxAge(0)
                 .build();
 
         ResponseCookie clearRefreshToken = ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
+                .secure(secure)
+                .sameSite(sameSite)
                 .path("/api/v1/auth")
                 .maxAge(0)
                 .build();

--- a/backend/src/main/java/com/pfwa/controller/CategoryController.java
+++ b/backend/src/main/java/com/pfwa/controller/CategoryController.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
  * REST controller for transaction categories.
  */
 @RestController
-@RequestMapping("/api/v1/categories")
+@RequestMapping("/categories")
 public class CategoryController {
 
     private static final Logger logger = LoggerFactory.getLogger(CategoryController.class);

--- a/backend/src/main/java/com/pfwa/controller/CategoryController.java
+++ b/backend/src/main/java/com/pfwa/controller/CategoryController.java
@@ -1,0 +1,53 @@
+package com.pfwa.controller;
+
+import com.pfwa.dto.transaction.CategoriesResponse;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.service.CategoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * REST controller for transaction categories.
+ */
+@RestController
+@RequestMapping("/api/v1/categories")
+public class CategoryController {
+
+    private static final Logger logger = LoggerFactory.getLogger(CategoryController.class);
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    /**
+     * Gets all transaction categories grouped by type.
+     * Results can be cached by clients as categories rarely change.
+     *
+     * @param type optional filter by transaction type
+     * @return categories grouped by income and expense
+     */
+    @GetMapping
+    public ResponseEntity<CategoriesResponse> getCategories(
+            @RequestParam(required = false) TransactionType type) {
+
+        logger.debug("GET /api/v1/categories - type: {}", type);
+
+        CategoriesResponse response = type != null ?
+                categoryService.getCategoriesByType(type) :
+                categoryService.getAllCategories();
+
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS))
+                .body(response);
+    }
+}

--- a/backend/src/main/java/com/pfwa/controller/TransactionController.java
+++ b/backend/src/main/java/com/pfwa/controller/TransactionController.java
@@ -1,0 +1,225 @@
+package com.pfwa.controller;
+
+import com.pfwa.dto.transaction.*;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.security.UserPrincipal;
+import com.pfwa.service.TransactionService;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * REST controller for managing transactions.
+ */
+@RestController
+@RequestMapping("/api/v1/transactions")
+public class TransactionController {
+
+    private static final Logger logger = LoggerFactory.getLogger(TransactionController.class);
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private final TransactionService transactionService;
+
+    public TransactionController(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    /**
+     * Creates a new transaction.
+     *
+     * @param principal the authenticated user
+     * @param request   the create transaction request
+     * @return the created transaction with 201 status
+     */
+    @PostMapping
+    public ResponseEntity<TransactionResponse> createTransaction(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody CreateTransactionRequest request) {
+
+        logger.debug("POST /api/v1/transactions - user: {}", principal.getId());
+
+        TransactionResponse response = transactionService.createTransaction(principal.getId(), request);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(response.id())
+                .toUri();
+
+        return ResponseEntity.created(location).body(response);
+    }
+
+    /**
+     * Gets a list of transactions with optional filtering, pagination, and sorting.
+     *
+     * @param principal   the authenticated user
+     * @param page        page number (0-indexed)
+     * @param size        page size (max 100)
+     * @param sort        sort field and direction (e.g., "date,desc")
+     * @param startDate   filter by start date (inclusive)
+     * @param endDate     filter by end date (inclusive)
+     * @param type        filter by transaction type
+     * @param categoryIds filter by category IDs
+     * @param minAmount   filter by minimum amount
+     * @param maxAmount   filter by maximum amount
+     * @param search      search in description and notes
+     * @return paginated list of transactions with summary
+     */
+    @GetMapping
+    public ResponseEntity<TransactionListResponse> getTransactions(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "" + DEFAULT_PAGE_SIZE) int size,
+            @RequestParam(defaultValue = "transactionDate,desc") String sort,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(required = false) TransactionType type,
+            @RequestParam(required = false) List<UUID> categoryIds,
+            @RequestParam(required = false) BigDecimal minAmount,
+            @RequestParam(required = false) BigDecimal maxAmount,
+            @RequestParam(required = false) String search) {
+
+        logger.debug("GET /api/v1/transactions - user: {}, page: {}, size: {}",
+                principal.getId(), page, size);
+
+        // Validate and constrain page size
+        int constrainedSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+
+        // Parse sort parameter
+        Pageable pageable = buildPageable(page, constrainedSize, sort);
+
+        // Build filter
+        TransactionFilterRequest filter = new TransactionFilterRequest(
+                startDate, endDate, type, categoryIds, minAmount, maxAmount, search);
+
+        TransactionListResponse response = transactionService.getTransactions(
+                principal.getId(), filter, pageable);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Gets a single transaction by ID.
+     *
+     * @param principal the authenticated user
+     * @param id        the transaction ID
+     * @return the transaction
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<TransactionResponse> getTransaction(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID id) {
+
+        logger.debug("GET /api/v1/transactions/{} - user: {}", id, principal.getId());
+
+        TransactionResponse response = transactionService.getTransaction(principal.getId(), id);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Updates an existing transaction.
+     *
+     * @param principal the authenticated user
+     * @param id        the transaction ID
+     * @param request   the update request
+     * @return the updated transaction
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<TransactionResponse> updateTransaction(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateTransactionRequest request) {
+
+        logger.debug("PUT /api/v1/transactions/{} - user: {}", id, principal.getId());
+
+        TransactionResponse response = transactionService.updateTransaction(principal.getId(), id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Deletes a transaction.
+     *
+     * @param principal the authenticated user
+     * @param id        the transaction ID
+     * @return 204 No Content on success
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTransaction(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable UUID id) {
+
+        logger.debug("DELETE /api/v1/transactions/{} - user: {}", id, principal.getId());
+
+        transactionService.deleteTransaction(principal.getId(), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Gets transaction summary and statistics.
+     *
+     * @param principal the authenticated user
+     * @param startDate the start date (optional)
+     * @param endDate   the end date (optional)
+     * @return the transaction summary
+     */
+    @GetMapping("/summary")
+    public ResponseEntity<TransactionSummaryResponse> getTransactionSummary(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate) {
+
+        logger.debug("GET /api/v1/transactions/summary - user: {}, start: {}, end: {}",
+                principal.getId(), startDate, endDate);
+
+        TransactionSummaryResponse response = transactionService.getTransactionSummary(
+                principal.getId(), startDate, endDate);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Builds a Pageable object from the sort parameter.
+     * Supports format: "field,direction" (e.g., "date,desc" or "amount,asc")
+     */
+    private Pageable buildPageable(int page, int size, String sort) {
+        if (sort == null || sort.isBlank()) {
+            return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "transactionDate"));
+        }
+
+        String[] parts = sort.split(",");
+        String field = mapSortField(parts[0].trim());
+        Sort.Direction direction = parts.length > 1 && "asc".equalsIgnoreCase(parts[1].trim()) ?
+                Sort.Direction.ASC : Sort.Direction.DESC;
+
+        return PageRequest.of(page, size, Sort.by(direction, field));
+    }
+
+    /**
+     * Maps API sort field names to entity field names.
+     */
+    private String mapSortField(String field) {
+        return switch (field.toLowerCase()) {
+            case "date", "transactiondate" -> "transactionDate";
+            case "amount" -> "amount";
+            case "category" -> "category.name";
+            case "createdat" -> "createdAt";
+            case "type" -> "type";
+            default -> "transactionDate";
+        };
+    }
+}

--- a/backend/src/main/java/com/pfwa/controller/TransactionController.java
+++ b/backend/src/main/java/com/pfwa/controller/TransactionController.java
@@ -25,7 +25,7 @@ import java.util.UUID;
  * REST controller for managing transactions.
  */
 @RestController
-@RequestMapping("/api/v1/transactions")
+@RequestMapping("/transactions")
 public class TransactionController {
 
     private static final Logger logger = LoggerFactory.getLogger(TransactionController.class);

--- a/backend/src/main/java/com/pfwa/dto/transaction/AppliedFilters.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/AppliedFilters.java
@@ -1,0 +1,39 @@
+package com.pfwa.dto.transaction;
+
+import com.pfwa.entity.TransactionType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * DTO representing the filters that were applied to a transaction query.
+ */
+public record AppliedFilters(
+        LocalDate startDate,
+        LocalDate endDate,
+        TransactionType type,
+        List<UUID> categoryIds,
+        BigDecimal minAmount,
+        BigDecimal maxAmount,
+        String search
+) {
+    /**
+     * Creates an AppliedFilters from a TransactionFilterRequest.
+     *
+     * @param filter the filter request
+     * @return the applied filters DTO
+     */
+    public static AppliedFilters from(TransactionFilterRequest filter) {
+        return new AppliedFilters(
+                filter.startDate(),
+                filter.endDate(),
+                filter.type(),
+                filter.categoryIds() != null ? filter.categoryIds() : List.of(),
+                filter.minAmount(),
+                filter.maxAmount(),
+                filter.search()
+        );
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/CategoriesResponse.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/CategoriesResponse.java
@@ -1,0 +1,24 @@
+package com.pfwa.dto.transaction;
+
+import java.util.List;
+
+/**
+ * Response DTO containing categories grouped by type.
+ */
+public record CategoriesResponse(
+        List<CategoryResponse> income,
+        List<CategoryResponse> expense
+) {
+    /**
+     * Creates a CategoriesResponse with income and expense categories.
+     *
+     * @param incomeCategories  list of income categories
+     * @param expenseCategories list of expense categories
+     * @return the categories response
+     */
+    public static CategoriesResponse of(
+            List<CategoryResponse> incomeCategories,
+            List<CategoryResponse> expenseCategories) {
+        return new CategoriesResponse(incomeCategories, expenseCategories);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/CategoryBreakdown.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/CategoryBreakdown.java
@@ -1,0 +1,24 @@
+package com.pfwa.dto.transaction;
+
+import java.util.List;
+
+/**
+ * DTO containing category breakdowns for income and expenses.
+ */
+public record CategoryBreakdown(
+        List<CategoryBreakdownItem> income,
+        List<CategoryBreakdownItem> expense
+) {
+    /**
+     * Creates a CategoryBreakdown with income and expense breakdowns.
+     *
+     * @param income  list of income category breakdowns
+     * @param expense list of expense category breakdowns
+     * @return the category breakdown
+     */
+    public static CategoryBreakdown of(
+            List<CategoryBreakdownItem> income,
+            List<CategoryBreakdownItem> expense) {
+        return new CategoryBreakdown(income, expense);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/CategoryBreakdownItem.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/CategoryBreakdownItem.java
@@ -1,0 +1,30 @@
+package com.pfwa.dto.transaction;
+
+import java.math.BigDecimal;
+
+/**
+ * DTO for a single category's breakdown in the summary.
+ */
+public record CategoryBreakdownItem(
+        CategorySummary category,
+        BigDecimal total,
+        BigDecimal percentage,
+        int transactionCount
+) {
+    /**
+     * Creates a CategoryBreakdownItem.
+     *
+     * @param category         the category summary
+     * @param total            the total amount for this category
+     * @param percentage       the percentage of total for this type
+     * @param transactionCount the number of transactions in this category
+     * @return the category breakdown item
+     */
+    public static CategoryBreakdownItem of(
+            CategorySummary category,
+            BigDecimal total,
+            BigDecimal percentage,
+            int transactionCount) {
+        return new CategoryBreakdownItem(category, total, percentage, transactionCount);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/CategoryResponse.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/CategoryResponse.java
@@ -1,0 +1,33 @@
+package com.pfwa.dto.transaction;
+
+import com.pfwa.entity.Category;
+import com.pfwa.entity.TransactionType;
+
+import java.util.UUID;
+
+/**
+ * Response DTO for category information.
+ */
+public record CategoryResponse(
+        UUID id,
+        String name,
+        TransactionType type,
+        String icon,
+        String color
+) {
+    /**
+     * Creates a CategoryResponse from a Category entity.
+     *
+     * @param category the category entity
+     * @return the category response DTO
+     */
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getType(),
+                category.getIcon(),
+                category.getColor()
+        );
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/CategorySummary.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/CategorySummary.java
@@ -1,0 +1,30 @@
+package com.pfwa.dto.transaction;
+
+import com.pfwa.entity.Category;
+
+import java.util.UUID;
+
+/**
+ * DTO for category information in summary breakdown.
+ */
+public record CategorySummary(
+        UUID id,
+        String name,
+        String icon,
+        String color
+) {
+    /**
+     * Creates a CategorySummary from a Category entity.
+     *
+     * @param category the category entity
+     * @return the category summary
+     */
+    public static CategorySummary from(Category category) {
+        return new CategorySummary(
+                category.getId(),
+                category.getName(),
+                category.getIcon(),
+                category.getColor()
+        );
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/CreateTransactionRequest.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/CreateTransactionRequest.java
@@ -1,0 +1,37 @@
+package com.pfwa.dto.transaction;
+
+import com.pfwa.entity.TransactionType;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Request DTO for creating a new transaction.
+ */
+public record CreateTransactionRequest(
+        @NotNull(message = "Amount is required")
+        @DecimalMin(value = "0.01", message = "Amount must be greater than 0")
+        @DecimalMax(value = "10000000", message = "Amount exceeds maximum allowed value")
+        BigDecimal amount,
+
+        @NotNull(message = "Transaction type is required")
+        TransactionType type,
+
+        @NotNull(message = "Category is required")
+        UUID categoryId,
+
+        @NotNull(message = "Date is required")
+        LocalDate date,
+
+        @Size(max = 500, message = "Description must be 500 characters or less")
+        String description,
+
+        @Size(max = 1000, message = "Notes must be 1000 characters or less")
+        String notes
+) {
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/PeriodChange.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/PeriodChange.java
@@ -1,0 +1,59 @@
+package com.pfwa.dto.transaction;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * DTO containing percentage changes compared to previous period.
+ */
+public record PeriodChange(
+        String income,
+        String expenses,
+        String net
+) {
+    /**
+     * Calculates percentage change and formats it as a string.
+     *
+     * @param current  current period value
+     * @param previous previous period value
+     * @return formatted percentage change (e.g., "+11.1%", "-5.2%", "0.0%")
+     */
+    public static String calculateChange(BigDecimal current, BigDecimal previous) {
+        if (previous.compareTo(BigDecimal.ZERO) == 0) {
+            if (current.compareTo(BigDecimal.ZERO) == 0) {
+                return "0.0%";
+            }
+            return current.compareTo(BigDecimal.ZERO) > 0 ? "+100.0%" : "-100.0%";
+        }
+
+        BigDecimal change = current.subtract(previous)
+                .divide(previous.abs(), 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(1, RoundingMode.HALF_UP);
+
+        String prefix = change.compareTo(BigDecimal.ZERO) >= 0 ? "+" : "";
+        return prefix + change + "%";
+    }
+
+    /**
+     * Creates a PeriodChange by calculating changes between current and previous periods.
+     *
+     * @param currentIncome   current period income
+     * @param previousIncome  previous period income
+     * @param currentExpenses current period expenses
+     * @param previousExpenses previous period expenses
+     * @param currentNet      current period net
+     * @param previousNet     previous period net
+     * @return the period change DTO
+     */
+    public static PeriodChange calculate(
+            BigDecimal currentIncome, BigDecimal previousIncome,
+            BigDecimal currentExpenses, BigDecimal previousExpenses,
+            BigDecimal currentNet, BigDecimal previousNet) {
+        return new PeriodChange(
+                calculateChange(currentIncome, previousIncome),
+                calculateChange(currentExpenses, previousExpenses),
+                calculateChange(currentNet, previousNet)
+        );
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/PeriodComparison.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/PeriodComparison.java
@@ -1,0 +1,20 @@
+package com.pfwa.dto.transaction;
+
+/**
+ * DTO containing comparison data between current and previous periods.
+ */
+public record PeriodComparison(
+        PreviousPeriodSummary previousPeriod,
+        PeriodChange change
+) {
+    /**
+     * Creates a PeriodComparison.
+     *
+     * @param previousPeriod the previous period summary
+     * @param change         the percentage changes
+     * @return the period comparison
+     */
+    public static PeriodComparison of(PreviousPeriodSummary previousPeriod, PeriodChange change) {
+        return new PeriodComparison(previousPeriod, change);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/PreviousPeriodSummary.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/PreviousPeriodSummary.java
@@ -1,0 +1,33 @@
+package com.pfwa.dto.transaction;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * DTO containing summary data for the previous comparison period.
+ */
+public record PreviousPeriodSummary(
+        LocalDate startDate,
+        LocalDate endDate,
+        BigDecimal income,
+        BigDecimal expenses,
+        BigDecimal net
+) {
+    /**
+     * Creates a PreviousPeriodSummary with calculated net balance.
+     *
+     * @param startDate the start date of the period
+     * @param endDate   the end date of the period
+     * @param income    total income
+     * @param expenses  total expenses
+     * @return the previous period summary
+     */
+    public static PreviousPeriodSummary of(
+            LocalDate startDate,
+            LocalDate endDate,
+            BigDecimal income,
+            BigDecimal expenses) {
+        BigDecimal net = income.subtract(expenses);
+        return new PreviousPeriodSummary(startDate, endDate, income, expenses, net);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/SummaryPeriod.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/SummaryPeriod.java
@@ -1,0 +1,22 @@
+package com.pfwa.dto.transaction;
+
+import java.time.LocalDate;
+
+/**
+ * DTO representing a time period for summary statistics.
+ */
+public record SummaryPeriod(
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    /**
+     * Creates a SummaryPeriod with the given dates.
+     *
+     * @param startDate the start date of the period
+     * @param endDate   the end date of the period
+     * @return the summary period
+     */
+    public static SummaryPeriod of(LocalDate startDate, LocalDate endDate) {
+        return new SummaryPeriod(startDate, endDate);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/SummaryTotals.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/SummaryTotals.java
@@ -1,0 +1,26 @@
+package com.pfwa.dto.transaction;
+
+import java.math.BigDecimal;
+
+/**
+ * DTO containing total amounts for a summary period.
+ */
+public record SummaryTotals(
+        BigDecimal income,
+        BigDecimal expenses,
+        BigDecimal net,
+        int transactionCount
+) {
+    /**
+     * Creates summary totals with calculated net balance.
+     *
+     * @param income           total income
+     * @param expenses         total expenses
+     * @param transactionCount total number of transactions
+     * @return the summary totals
+     */
+    public static SummaryTotals of(BigDecimal income, BigDecimal expenses, int transactionCount) {
+        BigDecimal net = income.subtract(expenses);
+        return new SummaryTotals(income, expenses, net, transactionCount);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/TransactionFilterRequest.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/TransactionFilterRequest.java
@@ -1,0 +1,48 @@
+package com.pfwa.dto.transaction;
+
+import com.pfwa.entity.TransactionType;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Request DTO for filtering transactions.
+ * All filters are optional and combined with AND logic.
+ */
+public record TransactionFilterRequest(
+        LocalDate startDate,
+        LocalDate endDate,
+        TransactionType type,
+        List<UUID> categoryIds,
+        @DecimalMin(value = "0", message = "Minimum amount cannot be negative")
+        BigDecimal minAmount,
+        @DecimalMin(value = "0", message = "Maximum amount cannot be negative")
+        BigDecimal maxAmount,
+        @Size(min = 2, max = 100, message = "Search term must be between 2 and 100 characters")
+        String search
+) {
+    /**
+     * Creates an empty filter (no filters applied).
+     *
+     * @return empty filter request
+     */
+    public static TransactionFilterRequest empty() {
+        return new TransactionFilterRequest(null, null, null, null, null, null, null);
+    }
+
+    /**
+     * Checks if any filter is applied.
+     *
+     * @return true if at least one filter is set
+     */
+    public boolean hasFilters() {
+        return startDate != null || endDate != null || type != null ||
+                (categoryIds != null && !categoryIds.isEmpty()) ||
+                minAmount != null || maxAmount != null ||
+                (search != null && !search.isBlank());
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/TransactionListResponse.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/TransactionListResponse.java
@@ -1,0 +1,45 @@
+package com.pfwa.dto.transaction;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * Response DTO for paginated list of transactions with summary.
+ */
+public record TransactionListResponse(
+        List<TransactionResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last,
+        TransactionListSummary summary,
+        AppliedFilters appliedFilters
+) {
+    /**
+     * Creates a TransactionListResponse from a Page of transactions.
+     *
+     * @param transactionPage the page of transaction responses
+     * @param summary         the summary statistics
+     * @param appliedFilters  the filters that were applied
+     * @return the transaction list response
+     */
+    public static TransactionListResponse from(
+            Page<TransactionResponse> transactionPage,
+            TransactionListSummary summary,
+            AppliedFilters appliedFilters) {
+        return new TransactionListResponse(
+                transactionPage.getContent(),
+                transactionPage.getNumber(),
+                transactionPage.getSize(),
+                transactionPage.getTotalElements(),
+                transactionPage.getTotalPages(),
+                transactionPage.isFirst(),
+                transactionPage.isLast(),
+                summary,
+                appliedFilters
+        );
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/TransactionListSummary.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/TransactionListSummary.java
@@ -1,0 +1,25 @@
+package com.pfwa.dto.transaction;
+
+import java.math.BigDecimal;
+
+/**
+ * Summary DTO containing totals for a list of transactions.
+ */
+public record TransactionListSummary(
+        BigDecimal totalIncome,
+        BigDecimal totalExpenses,
+        BigDecimal netBalance
+) {
+    /**
+     * Creates a summary with the given totals.
+     * Net balance is calculated as income minus expenses.
+     *
+     * @param totalIncome   total income amount
+     * @param totalExpenses total expenses amount
+     * @return the transaction list summary
+     */
+    public static TransactionListSummary of(BigDecimal totalIncome, BigDecimal totalExpenses) {
+        BigDecimal net = totalIncome.subtract(totalExpenses);
+        return new TransactionListSummary(totalIncome, totalExpenses, net);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/TransactionResponse.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/TransactionResponse.java
@@ -1,0 +1,44 @@
+package com.pfwa.dto.transaction;
+
+import com.pfwa.entity.Transaction;
+import com.pfwa.entity.TransactionType;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Response DTO for a single transaction.
+ */
+public record TransactionResponse(
+        UUID id,
+        BigDecimal amount,
+        TransactionType type,
+        CategoryResponse category,
+        LocalDate date,
+        String description,
+        String notes,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    /**
+     * Creates a TransactionResponse from a Transaction entity.
+     *
+     * @param transaction the transaction entity
+     * @return the transaction response DTO
+     */
+    public static TransactionResponse from(Transaction transaction) {
+        return new TransactionResponse(
+                transaction.getId(),
+                transaction.getAmount(),
+                transaction.getType(),
+                CategoryResponse.from(transaction.getCategory()),
+                transaction.getTransactionDate(),
+                transaction.getDescription(),
+                transaction.getNotes(),
+                transaction.getCreatedAt(),
+                transaction.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/TransactionSummaryResponse.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/TransactionSummaryResponse.java
@@ -1,0 +1,31 @@
+package com.pfwa.dto.transaction;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Response DTO for transaction summary and statistics.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TransactionSummaryResponse(
+        SummaryPeriod period,
+        SummaryTotals totals,
+        CategoryBreakdown categoryBreakdown,
+        PeriodComparison comparison
+) {
+    /**
+     * Creates a TransactionSummaryResponse.
+     *
+     * @param period            the summary period
+     * @param totals            the totals for the period
+     * @param categoryBreakdown the category breakdown
+     * @param comparison        the comparison with previous period (optional)
+     * @return the transaction summary response
+     */
+    public static TransactionSummaryResponse of(
+            SummaryPeriod period,
+            SummaryTotals totals,
+            CategoryBreakdown categoryBreakdown,
+            PeriodComparison comparison) {
+        return new TransactionSummaryResponse(period, totals, categoryBreakdown, comparison);
+    }
+}

--- a/backend/src/main/java/com/pfwa/dto/transaction/UpdateTransactionRequest.java
+++ b/backend/src/main/java/com/pfwa/dto/transaction/UpdateTransactionRequest.java
@@ -1,0 +1,37 @@
+package com.pfwa.dto.transaction;
+
+import com.pfwa.entity.TransactionType;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * Request DTO for updating an existing transaction.
+ */
+public record UpdateTransactionRequest(
+        @NotNull(message = "Amount is required")
+        @DecimalMin(value = "0.01", message = "Amount must be greater than 0")
+        @DecimalMax(value = "10000000", message = "Amount exceeds maximum allowed value")
+        BigDecimal amount,
+
+        @NotNull(message = "Transaction type is required")
+        TransactionType type,
+
+        @NotNull(message = "Category is required")
+        UUID categoryId,
+
+        @NotNull(message = "Date is required")
+        LocalDate date,
+
+        @Size(max = 500, message = "Description must be 500 characters or less")
+        String description,
+
+        @Size(max = 1000, message = "Notes must be 1000 characters or less")
+        String notes
+) {
+}

--- a/backend/src/main/java/com/pfwa/entity/Category.java
+++ b/backend/src/main/java/com/pfwa/entity/Category.java
@@ -1,0 +1,165 @@
+package com.pfwa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Category entity representing the categories table.
+ * Contains predefined categories for transaction classification.
+ */
+@Entity
+@Table(name = "categories")
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private TransactionType type;
+
+    @Column(name = "icon", length = 50)
+    private String icon;
+
+    @Column(name = "color", length = 7)
+    private String color;
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder = 0;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    // Default constructor required by JPA
+    public Category() {
+    }
+
+    // Constructor for creating new categories
+    public Category(String name, TransactionType type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    // Full constructor
+    public Category(String name, TransactionType type, String icon, String color, int displayOrder) {
+        this.name = name;
+        this.type = type;
+        this.icon = icon;
+        this.color = color;
+        this.displayOrder = displayOrder;
+    }
+
+    // Getters and Setters
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public void setType(TransactionType type) {
+        this.type = type;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public int getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public void setDisplayOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    // equals and hashCode based on id (business key)
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Category category = (Category) o;
+        return id != null && Objects.equals(id, category.id);
+    }
+
+    @Override
+    public int hashCode() {
+        // Use a constant hash code for unsaved entities
+        return getClass().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Category{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", type=" + type +
+                ", icon='" + icon + '\'' +
+                ", displayOrder=" + displayOrder +
+                ", active=" + active +
+                '}';
+    }
+}

--- a/backend/src/main/java/com/pfwa/entity/Transaction.java
+++ b/backend/src/main/java/com/pfwa/entity/Transaction.java
@@ -1,0 +1,230 @@
+package com.pfwa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Transaction entity representing the transactions table.
+ * Contains financial transactions (income and expenses) for users.
+ */
+@Entity
+@Table(name = "transactions")
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(name = "amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private TransactionType type;
+
+    @Column(name = "transaction_date", nullable = false)
+    private LocalDate transactionDate;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    // Default constructor required by JPA
+    public Transaction() {
+    }
+
+    // Constructor for creating new transactions
+    public Transaction(User user, Category category, BigDecimal amount, TransactionType type, LocalDate transactionDate) {
+        this.user = user;
+        this.category = category;
+        this.amount = amount;
+        this.type = type;
+        this.transactionDate = transactionDate;
+    }
+
+    // Getters and Setters
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public void setCategory(Category category) {
+        this.category = category;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public void setType(TransactionType type) {
+        this.type = type;
+    }
+
+    public LocalDate getTransactionDate() {
+        return transactionDate;
+    }
+
+    public void setTransactionDate(LocalDate transactionDate) {
+        this.transactionDate = transactionDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // Business logic methods
+
+    /**
+     * Checks if this is an income transaction.
+     *
+     * @return true if type is INCOME
+     */
+    public boolean isIncome() {
+        return TransactionType.INCOME.equals(type);
+    }
+
+    /**
+     * Checks if this is an expense transaction.
+     *
+     * @return true if type is EXPENSE
+     */
+    public boolean isExpense() {
+        return TransactionType.EXPENSE.equals(type);
+    }
+
+    /**
+     * Gets the user ID without loading the full User entity.
+     * Useful for avoiding N+1 queries.
+     *
+     * @return the user ID or null if user is not set
+     */
+    public UUID getUserId() {
+        return user != null ? user.getId() : null;
+    }
+
+    /**
+     * Gets the category ID without loading the full Category entity.
+     * Useful for avoiding N+1 queries.
+     *
+     * @return the category ID or null if category is not set
+     */
+    public UUID getCategoryId() {
+        return category != null ? category.getId() : null;
+    }
+
+    // equals and hashCode based on id (business key)
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Transaction that = (Transaction) o;
+        return id != null && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        // Use a constant hash code for unsaved entities
+        return getClass().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Transaction{" +
+                "id=" + id +
+                ", amount=" + amount +
+                ", type=" + type +
+                ", transactionDate=" + transactionDate +
+                ", description='" + description + '\'' +
+                ", createdAt=" + createdAt +
+                '}';
+    }
+}

--- a/backend/src/main/java/com/pfwa/entity/TransactionType.java
+++ b/backend/src/main/java/com/pfwa/entity/TransactionType.java
@@ -1,0 +1,20 @@
+package com.pfwa.entity;
+
+/**
+ * Enum representing the types of financial transactions.
+ * Maps to the PostgreSQL enum type 'transaction_type'.
+ */
+public enum TransactionType {
+
+    /**
+     * Income transaction - money coming in.
+     * Examples: Salary, freelance payments, investment returns.
+     */
+    INCOME,
+
+    /**
+     * Expense transaction - money going out.
+     * Examples: Food, transportation, utilities.
+     */
+    EXPENSE
+}

--- a/backend/src/main/java/com/pfwa/exception/CategoryNotFoundException.java
+++ b/backend/src/main/java/com/pfwa/exception/CategoryNotFoundException.java
@@ -1,0 +1,25 @@
+package com.pfwa.exception;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a category is not found.
+ */
+public class CategoryNotFoundException extends RuntimeException {
+
+    private final UUID categoryId;
+
+    public CategoryNotFoundException(UUID categoryId) {
+        super("Category not found");
+        this.categoryId = categoryId;
+    }
+
+    public CategoryNotFoundException(String message) {
+        super(message);
+        this.categoryId = null;
+    }
+
+    public UUID getCategoryId() {
+        return categoryId;
+    }
+}

--- a/backend/src/main/java/com/pfwa/exception/CategoryTypeMismatchException.java
+++ b/backend/src/main/java/com/pfwa/exception/CategoryTypeMismatchException.java
@@ -1,0 +1,34 @@
+package com.pfwa.exception;
+
+import com.pfwa.entity.TransactionType;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when category type does not match transaction type.
+ */
+public class CategoryTypeMismatchException extends RuntimeException {
+
+    private final UUID categoryId;
+    private final TransactionType expectedType;
+    private final TransactionType actualType;
+
+    public CategoryTypeMismatchException(UUID categoryId, TransactionType expectedType, TransactionType actualType) {
+        super("Category type must match transaction type");
+        this.categoryId = categoryId;
+        this.expectedType = expectedType;
+        this.actualType = actualType;
+    }
+
+    public UUID getCategoryId() {
+        return categoryId;
+    }
+
+    public TransactionType getExpectedType() {
+        return expectedType;
+    }
+
+    public TransactionType getActualType() {
+        return actualType;
+    }
+}

--- a/backend/src/main/java/com/pfwa/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/pfwa/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -231,6 +232,102 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(
                         "NOT_FOUND",
                         ex.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * Handles transaction not found exception.
+     */
+    @ExceptionHandler(TransactionNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleTransactionNotFound(
+            TransactionNotFoundException ex,
+            HttpServletRequest request) {
+
+        logger.debug("Transaction not found on {}", request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(
+                        "NOT_FOUND",
+                        ex.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * Handles category not found exception.
+     */
+    @ExceptionHandler(CategoryNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCategoryNotFound(
+            CategoryNotFoundException ex,
+            HttpServletRequest request) {
+
+        logger.debug("Category not found on {}", request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(
+                        "NOT_FOUND",
+                        ex.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * Handles category type mismatch exception.
+     */
+    @ExceptionHandler(CategoryTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleCategoryTypeMismatch(
+            CategoryTypeMismatchException ex,
+            HttpServletRequest request) {
+
+        logger.debug("Category type mismatch on {}", request.getRequestURI());
+
+        List<FieldError> fieldErrors = List.of(
+                FieldError.of("categoryId", ex.getMessage(), "category.type.mismatch")
+        );
+
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.withFieldErrors(
+                        "VALIDATION_ERROR",
+                        "Validation failed",
+                        request.getRequestURI(),
+                        fieldErrors
+                ));
+    }
+
+    /**
+     * Handles transaction access denied exception.
+     */
+    @ExceptionHandler(TransactionAccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleTransactionAccessDenied(
+            TransactionAccessDeniedException ex,
+            HttpServletRequest request) {
+
+        logger.debug("Transaction access denied on {}", request.getRequestURI());
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ErrorResponse.of(
+                        "FORBIDDEN",
+                        ex.getMessage(),
+                        request.getRequestURI()
+                ));
+    }
+
+    /**
+     * Handles method argument type mismatch (e.g., invalid UUID format).
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(
+            MethodArgumentTypeMismatchException ex,
+            HttpServletRequest request) {
+
+        logger.debug("Type mismatch on {}: {}", request.getRequestURI(), ex.getMessage());
+
+        String message = String.format("Invalid value for parameter '%s'", ex.getName());
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(
+                        "BAD_REQUEST",
+                        message,
                         request.getRequestURI()
                 ));
     }

--- a/backend/src/main/java/com/pfwa/exception/TransactionAccessDeniedException.java
+++ b/backend/src/main/java/com/pfwa/exception/TransactionAccessDeniedException.java
@@ -1,0 +1,26 @@
+package com.pfwa.exception;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a user attempts to access a transaction they do not own.
+ */
+public class TransactionAccessDeniedException extends RuntimeException {
+
+    private final UUID transactionId;
+    private final UUID userId;
+
+    public TransactionAccessDeniedException(UUID transactionId, UUID userId) {
+        super("You do not have permission to access this transaction");
+        this.transactionId = transactionId;
+        this.userId = userId;
+    }
+
+    public UUID getTransactionId() {
+        return transactionId;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+}

--- a/backend/src/main/java/com/pfwa/exception/TransactionNotFoundException.java
+++ b/backend/src/main/java/com/pfwa/exception/TransactionNotFoundException.java
@@ -1,0 +1,25 @@
+package com.pfwa.exception;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a transaction is not found or user does not have access.
+ */
+public class TransactionNotFoundException extends RuntimeException {
+
+    private final UUID transactionId;
+
+    public TransactionNotFoundException(UUID transactionId) {
+        super("Transaction not found");
+        this.transactionId = transactionId;
+    }
+
+    public TransactionNotFoundException(String message) {
+        super(message);
+        this.transactionId = null;
+    }
+
+    public UUID getTransactionId() {
+        return transactionId;
+    }
+}

--- a/backend/src/main/java/com/pfwa/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/pfwa/repository/CategoryRepository.java
@@ -1,0 +1,91 @@
+package com.pfwa.repository;
+
+import com.pfwa.entity.Category;
+import com.pfwa.entity.TransactionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for Category entity operations.
+ * Provides methods for category lookup and filtering.
+ */
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+    /**
+     * Finds all active categories ordered by display order.
+     *
+     * @return list of active categories sorted by display order
+     */
+    @Query("SELECT c FROM Category c WHERE c.active = true ORDER BY c.displayOrder")
+    List<Category> findAllActiveOrderByDisplayOrder();
+
+    /**
+     * Finds all active categories of a specific type ordered by display order.
+     *
+     * @param type the transaction type (INCOME or EXPENSE)
+     * @return list of active categories of the specified type
+     */
+    @Query("SELECT c FROM Category c WHERE c.type = :type AND c.active = true ORDER BY c.displayOrder")
+    List<Category> findByTypeAndActiveOrderByDisplayOrder(@Param("type") TransactionType type);
+
+    /**
+     * Finds a category by name and type.
+     *
+     * @param name the category name
+     * @param type the transaction type
+     * @return Optional containing the category if found
+     */
+    Optional<Category> findByNameAndType(String name, TransactionType type);
+
+    /**
+     * Finds all income categories ordered by display order.
+     *
+     * @return list of active income categories
+     */
+    default List<Category> findAllIncomeCategories() {
+        return findByTypeAndActiveOrderByDisplayOrder(TransactionType.INCOME);
+    }
+
+    /**
+     * Finds all expense categories ordered by display order.
+     *
+     * @return list of active expense categories
+     */
+    default List<Category> findAllExpenseCategories() {
+        return findByTypeAndActiveOrderByDisplayOrder(TransactionType.EXPENSE);
+    }
+
+    /**
+     * Checks if a category exists and is active.
+     *
+     * @param id the category ID
+     * @return true if category exists and is active
+     */
+    @Query("SELECT CASE WHEN COUNT(c) > 0 THEN true ELSE false END FROM Category c WHERE c.id = :id AND c.active = true")
+    boolean existsByIdAndActive(@Param("id") UUID id);
+
+    /**
+     * Finds a category by ID only if it is active.
+     *
+     * @param id the category ID
+     * @return Optional containing the active category if found
+     */
+    @Query("SELECT c FROM Category c WHERE c.id = :id AND c.active = true")
+    Optional<Category> findByIdAndActive(@Param("id") UUID id);
+
+    /**
+     * Finds categories by a list of IDs.
+     *
+     * @param ids the list of category IDs
+     * @return list of categories matching the IDs
+     */
+    @Query("SELECT c FROM Category c WHERE c.id IN :ids AND c.active = true")
+    List<Category> findByIdsAndActive(@Param("ids") List<UUID> ids);
+}

--- a/backend/src/main/java/com/pfwa/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/pfwa/repository/TransactionRepository.java
@@ -1,0 +1,254 @@
+package com.pfwa.repository;
+
+import com.pfwa.entity.Transaction;
+import com.pfwa.entity.TransactionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository for Transaction entity operations.
+ * Provides methods for transaction CRUD, filtering, search, and aggregations.
+ * Extends JpaSpecificationExecutor for dynamic query building.
+ */
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, UUID>, JpaSpecificationExecutor<Transaction> {
+
+    /**
+     * Finds a transaction by ID and user ID.
+     * Used to verify ownership before update/delete.
+     *
+     * @param id the transaction ID
+     * @param userId the user ID
+     * @return Optional containing the transaction if found and owned by user
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.id = :id AND t.user.id = :userId")
+    Optional<Transaction> findByIdAndUserId(@Param("id") UUID id, @Param("userId") UUID userId);
+
+    /**
+     * Finds all transactions for a user with pagination.
+     *
+     * @param userId the user ID
+     * @param pageable pagination parameters
+     * @return page of transactions
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId")
+    Page<Transaction> findByUserId(@Param("userId") UUID userId, Pageable pageable);
+
+    /**
+     * Finds all transactions for a user within a date range.
+     *
+     * @param userId the user ID
+     * @param startDate the start date (inclusive)
+     * @param endDate the end date (inclusive)
+     * @param pageable pagination parameters
+     * @return page of transactions within the date range
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId " +
+           "AND t.transactionDate >= :startDate AND t.transactionDate <= :endDate")
+    Page<Transaction> findByUserIdAndDateRange(
+            @Param("userId") UUID userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable);
+
+    /**
+     * Finds all transactions for a user by type.
+     *
+     * @param userId the user ID
+     * @param type the transaction type
+     * @param pageable pagination parameters
+     * @return page of transactions of the specified type
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId AND t.type = :type")
+    Page<Transaction> findByUserIdAndType(
+            @Param("userId") UUID userId,
+            @Param("type") TransactionType type,
+            Pageable pageable);
+
+    /**
+     * Finds all transactions for a user by category.
+     *
+     * @param userId the user ID
+     * @param categoryId the category ID
+     * @param pageable pagination parameters
+     * @return page of transactions in the specified category
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId AND t.category.id = :categoryId")
+    Page<Transaction> findByUserIdAndCategoryId(
+            @Param("userId") UUID userId,
+            @Param("categoryId") UUID categoryId,
+            Pageable pageable);
+
+    /**
+     * Searches transactions by description or notes (case-insensitive partial match).
+     *
+     * @param userId the user ID
+     * @param searchTerm the search term
+     * @param pageable pagination parameters
+     * @return page of matching transactions
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId " +
+           "AND (LOWER(t.description) LIKE LOWER(CONCAT('%', :searchTerm, '%')) " +
+           "OR LOWER(t.notes) LIKE LOWER(CONCAT('%', :searchTerm, '%')))")
+    Page<Transaction> searchByDescriptionOrNotes(
+            @Param("userId") UUID userId,
+            @Param("searchTerm") String searchTerm,
+            Pageable pageable);
+
+    /**
+     * Calculates the total amount of transactions by type for a user.
+     *
+     * @param userId the user ID
+     * @param type the transaction type
+     * @return the sum of amounts (null if no transactions)
+     */
+    @Query("SELECT COALESCE(SUM(t.amount), 0) FROM Transaction t WHERE t.user.id = :userId AND t.type = :type")
+    BigDecimal sumAmountByUserIdAndType(@Param("userId") UUID userId, @Param("type") TransactionType type);
+
+    /**
+     * Calculates the total amount by type within a date range.
+     *
+     * @param userId the user ID
+     * @param type the transaction type
+     * @param startDate the start date (inclusive)
+     * @param endDate the end date (inclusive)
+     * @return the sum of amounts
+     */
+    @Query("SELECT COALESCE(SUM(t.amount), 0) FROM Transaction t WHERE t.user.id = :userId " +
+           "AND t.type = :type AND t.transactionDate >= :startDate AND t.transactionDate <= :endDate")
+    BigDecimal sumAmountByUserIdAndTypeAndDateRange(
+            @Param("userId") UUID userId,
+            @Param("type") TransactionType type,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+
+    /**
+     * Calculates the total amount by category within a date range.
+     *
+     * @param userId the user ID
+     * @param categoryId the category ID
+     * @param startDate the start date (inclusive)
+     * @param endDate the end date (inclusive)
+     * @return the sum of amounts
+     */
+    @Query("SELECT COALESCE(SUM(t.amount), 0) FROM Transaction t WHERE t.user.id = :userId " +
+           "AND t.category.id = :categoryId AND t.transactionDate >= :startDate AND t.transactionDate <= :endDate")
+    BigDecimal sumAmountByUserIdAndCategoryIdAndDateRange(
+            @Param("userId") UUID userId,
+            @Param("categoryId") UUID categoryId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+
+    /**
+     * Counts transactions for a user.
+     *
+     * @param userId the user ID
+     * @return the count of transactions
+     */
+    @Query("SELECT COUNT(t) FROM Transaction t WHERE t.user.id = :userId")
+    long countByUserId(@Param("userId") UUID userId);
+
+    /**
+     * Counts transactions by type within a date range.
+     *
+     * @param userId the user ID
+     * @param type the transaction type
+     * @param startDate the start date (inclusive)
+     * @param endDate the end date (inclusive)
+     * @return the count of transactions
+     */
+    @Query("SELECT COUNT(t) FROM Transaction t WHERE t.user.id = :userId " +
+           "AND t.type = :type AND t.transactionDate >= :startDate AND t.transactionDate <= :endDate")
+    long countByUserIdAndTypeAndDateRange(
+            @Param("userId") UUID userId,
+            @Param("type") TransactionType type,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+
+    /**
+     * Deletes a transaction by ID and user ID.
+     * Returns the number of deleted rows (0 or 1).
+     *
+     * @param id the transaction ID
+     * @param userId the user ID
+     * @return number of deleted rows
+     */
+    @Modifying
+    @Query("DELETE FROM Transaction t WHERE t.id = :id AND t.user.id = :userId")
+    int deleteByIdAndUserId(@Param("id") UUID id, @Param("userId") UUID userId);
+
+    /**
+     * Deletes multiple transactions by IDs and user ID (bulk delete).
+     *
+     * @param ids the list of transaction IDs
+     * @param userId the user ID
+     * @return number of deleted rows
+     */
+    @Modifying
+    @Query("DELETE FROM Transaction t WHERE t.id IN :ids AND t.user.id = :userId")
+    int deleteByIdsAndUserId(@Param("ids") List<UUID> ids, @Param("userId") UUID userId);
+
+    /**
+     * Checks if a transaction exists and belongs to a user.
+     *
+     * @param id the transaction ID
+     * @param userId the user ID
+     * @return true if transaction exists and belongs to user
+     */
+    @Query("SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM Transaction t " +
+           "WHERE t.id = :id AND t.user.id = :userId")
+    boolean existsByIdAndUserId(@Param("id") UUID id, @Param("userId") UUID userId);
+
+    /**
+     * Finds transactions with eager loading of category (avoids N+1).
+     *
+     * @param userId the user ID
+     * @param pageable pagination parameters
+     * @return page of transactions with categories loaded
+     */
+    @Query("SELECT t FROM Transaction t JOIN FETCH t.category WHERE t.user.id = :userId")
+    Page<Transaction> findByUserIdWithCategory(@Param("userId") UUID userId, Pageable pageable);
+
+    /**
+     * Finds all transactions for a user by category IDs.
+     *
+     * @param userId the user ID
+     * @param categoryIds the list of category IDs
+     * @param pageable pagination parameters
+     * @return page of transactions in the specified categories
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId AND t.category.id IN :categoryIds")
+    Page<Transaction> findByUserIdAndCategoryIds(
+            @Param("userId") UUID userId,
+            @Param("categoryIds") List<UUID> categoryIds,
+            Pageable pageable);
+
+    /**
+     * Finds transactions within an amount range.
+     *
+     * @param userId the user ID
+     * @param minAmount the minimum amount (inclusive)
+     * @param maxAmount the maximum amount (inclusive)
+     * @param pageable pagination parameters
+     * @return page of transactions within the amount range
+     */
+    @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId " +
+           "AND t.amount >= :minAmount AND t.amount <= :maxAmount")
+    Page<Transaction> findByUserIdAndAmountRange(
+            @Param("userId") UUID userId,
+            @Param("minAmount") BigDecimal minAmount,
+            @Param("maxAmount") BigDecimal maxAmount,
+            Pageable pageable);
+}

--- a/backend/src/main/java/com/pfwa/service/CategoryService.java
+++ b/backend/src/main/java/com/pfwa/service/CategoryService.java
@@ -1,0 +1,109 @@
+package com.pfwa.service;
+
+import com.pfwa.dto.transaction.CategoriesResponse;
+import com.pfwa.dto.transaction.CategoryResponse;
+import com.pfwa.entity.Category;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.exception.CategoryNotFoundException;
+import com.pfwa.repository.CategoryRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service for managing transaction categories.
+ */
+@Service
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CategoryService.class);
+
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    /**
+     * Gets all categories grouped by type.
+     *
+     * @return categories response with income and expense categories
+     */
+    public CategoriesResponse getAllCategories() {
+        logger.debug("Fetching all categories");
+
+        List<CategoryResponse> incomeCategories = categoryRepository.findAllIncomeCategories()
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+
+        List<CategoryResponse> expenseCategories = categoryRepository.findAllExpenseCategories()
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+
+        return CategoriesResponse.of(incomeCategories, expenseCategories);
+    }
+
+    /**
+     * Gets categories filtered by type.
+     *
+     * @param type the transaction type (optional, if null returns all)
+     * @return categories response
+     */
+    public CategoriesResponse getCategoriesByType(TransactionType type) {
+        logger.debug("Fetching categories by type: {}", type);
+
+        if (type == null) {
+            return getAllCategories();
+        }
+
+        List<CategoryResponse> categories = categoryRepository
+                .findByTypeAndActiveOrderByDisplayOrder(type)
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+
+        if (type == TransactionType.INCOME) {
+            return CategoriesResponse.of(categories, List.of());
+        } else {
+            return CategoriesResponse.of(List.of(), categories);
+        }
+    }
+
+    /**
+     * Gets a category by ID.
+     *
+     * @param categoryId the category ID
+     * @return the category entity
+     * @throws CategoryNotFoundException if category not found or inactive
+     */
+    public Category getCategoryById(UUID categoryId) {
+        return categoryRepository.findByIdAndActive(categoryId)
+                .orElseThrow(() -> new CategoryNotFoundException(categoryId));
+    }
+
+    /**
+     * Validates that a category exists, is active, and matches the expected type.
+     *
+     * @param categoryId   the category ID
+     * @param expectedType the expected transaction type
+     * @return the category entity
+     * @throws CategoryNotFoundException if category not found or inactive
+     */
+    public Category validateCategoryForType(UUID categoryId, TransactionType expectedType) {
+        Category category = getCategoryById(categoryId);
+
+        if (category.getType() != expectedType) {
+            logger.debug("Category {} has type {} but expected {}",
+                    categoryId, category.getType(), expectedType);
+        }
+
+        return category;
+    }
+}

--- a/backend/src/main/java/com/pfwa/service/TransactionService.java
+++ b/backend/src/main/java/com/pfwa/service/TransactionService.java
@@ -1,0 +1,390 @@
+package com.pfwa.service;
+
+import com.pfwa.dto.transaction.*;
+import com.pfwa.entity.Category;
+import com.pfwa.entity.Transaction;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.entity.User;
+import com.pfwa.exception.CategoryTypeMismatchException;
+import com.pfwa.exception.TransactionNotFoundException;
+import com.pfwa.repository.CategoryRepository;
+import com.pfwa.repository.TransactionRepository;
+import com.pfwa.repository.UserRepository;
+import com.pfwa.specification.TransactionSpecification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Service for managing transactions.
+ * Handles CRUD operations, filtering, search, and summary statistics.
+ */
+@Service
+@Transactional(readOnly = true)
+public class TransactionService {
+
+    private static final Logger logger = LoggerFactory.getLogger(TransactionService.class);
+
+    private final TransactionRepository transactionRepository;
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+    private final CategoryService categoryService;
+
+    public TransactionService(
+            TransactionRepository transactionRepository,
+            CategoryRepository categoryRepository,
+            UserRepository userRepository,
+            CategoryService categoryService) {
+        this.transactionRepository = transactionRepository;
+        this.categoryRepository = categoryRepository;
+        this.userRepository = userRepository;
+        this.categoryService = categoryService;
+    }
+
+    /**
+     * Creates a new transaction.
+     *
+     * @param userId  the ID of the user creating the transaction
+     * @param request the create transaction request
+     * @return the created transaction response
+     */
+    @Transactional
+    public TransactionResponse createTransaction(UUID userId, CreateTransactionRequest request) {
+        logger.debug("Creating transaction for user {}", userId);
+
+        User user = userRepository.getReferenceById(userId);
+        Category category = validateAndGetCategory(request.categoryId(), request.type());
+
+        Transaction transaction = new Transaction(
+                user,
+                category,
+                request.amount(),
+                request.type(),
+                request.date()
+        );
+        transaction.setDescription(request.description());
+        transaction.setNotes(request.notes());
+
+        Transaction saved = transactionRepository.save(transaction);
+        logger.info("Created transaction {} for user {}", saved.getId(), userId);
+
+        return TransactionResponse.from(saved);
+    }
+
+    /**
+     * Gets a transaction by ID for a specific user.
+     *
+     * @param userId        the user ID
+     * @param transactionId the transaction ID
+     * @return the transaction response
+     * @throws TransactionNotFoundException if transaction not found or not owned by user
+     */
+    public TransactionResponse getTransaction(UUID userId, UUID transactionId) {
+        Transaction transaction = transactionRepository.findByIdAndUserId(transactionId, userId)
+                .orElseThrow(() -> new TransactionNotFoundException(transactionId));
+
+        return TransactionResponse.from(transaction);
+    }
+
+    /**
+     * Gets a paginated list of transactions with optional filtering.
+     *
+     * @param userId   the user ID
+     * @param filter   the filter request (optional)
+     * @param pageable pagination parameters
+     * @return the transaction list response with summary
+     */
+    public TransactionListResponse getTransactions(
+            UUID userId,
+            TransactionFilterRequest filter,
+            Pageable pageable) {
+
+        logger.debug("Fetching transactions for user {} with filters: {}", userId, filter);
+
+        // Build specification with filters
+        Specification<Transaction> spec = TransactionSpecification.fromFilter(userId, filter);
+
+        // Fetch transactions with category eagerly loaded
+        spec = spec.and(TransactionSpecification.fetchCategory());
+
+        Page<Transaction> transactionPage = transactionRepository.findAll(spec, pageable);
+
+        // Map to DTOs
+        Page<TransactionResponse> responsePage = transactionPage.map(TransactionResponse::from);
+
+        // Calculate summary for filtered transactions
+        TransactionListSummary summary = calculateSummaryForFilter(userId, filter);
+
+        // Build applied filters
+        AppliedFilters appliedFilters = filter != null ? AppliedFilters.from(filter) :
+                AppliedFilters.from(TransactionFilterRequest.empty());
+
+        return TransactionListResponse.from(responsePage, summary, appliedFilters);
+    }
+
+    /**
+     * Updates an existing transaction.
+     *
+     * @param userId        the user ID
+     * @param transactionId the transaction ID
+     * @param request       the update request
+     * @return the updated transaction response
+     * @throws TransactionNotFoundException if transaction not found or not owned by user
+     */
+    @Transactional
+    public TransactionResponse updateTransaction(
+            UUID userId,
+            UUID transactionId,
+            UpdateTransactionRequest request) {
+
+        logger.debug("Updating transaction {} for user {}", transactionId, userId);
+
+        Transaction transaction = transactionRepository.findByIdAndUserId(transactionId, userId)
+                .orElseThrow(() -> new TransactionNotFoundException(transactionId));
+
+        Category category = validateAndGetCategory(request.categoryId(), request.type());
+
+        transaction.setAmount(request.amount());
+        transaction.setType(request.type());
+        transaction.setCategory(category);
+        transaction.setTransactionDate(request.date());
+        transaction.setDescription(request.description());
+        transaction.setNotes(request.notes());
+
+        Transaction saved = transactionRepository.save(transaction);
+        logger.info("Updated transaction {} for user {}", transactionId, userId);
+
+        return TransactionResponse.from(saved);
+    }
+
+    /**
+     * Deletes a transaction.
+     *
+     * @param userId        the user ID
+     * @param transactionId the transaction ID
+     * @throws TransactionNotFoundException if transaction not found or not owned by user
+     */
+    @Transactional
+    public void deleteTransaction(UUID userId, UUID transactionId) {
+        logger.debug("Deleting transaction {} for user {}", transactionId, userId);
+
+        int deleted = transactionRepository.deleteByIdAndUserId(transactionId, userId);
+        if (deleted == 0) {
+            throw new TransactionNotFoundException(transactionId);
+        }
+
+        logger.info("Deleted transaction {} for user {}", transactionId, userId);
+    }
+
+    /**
+     * Gets transaction summary and statistics.
+     *
+     * @param userId    the user ID
+     * @param startDate the start date (optional)
+     * @param endDate   the end date (optional)
+     * @return the transaction summary response
+     */
+    public TransactionSummaryResponse getTransactionSummary(
+            UUID userId,
+            LocalDate startDate,
+            LocalDate endDate) {
+
+        logger.debug("Getting summary for user {} from {} to {}", userId, startDate, endDate);
+
+        // Default to current month if no dates provided
+        LocalDate effectiveStartDate = startDate != null ? startDate : LocalDate.now().withDayOfMonth(1);
+        LocalDate effectiveEndDate = endDate != null ? endDate : LocalDate.now();
+
+        // Build period
+        SummaryPeriod period = SummaryPeriod.of(effectiveStartDate, effectiveEndDate);
+
+        // Calculate totals
+        BigDecimal totalIncome = transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                userId, TransactionType.INCOME, effectiveStartDate, effectiveEndDate);
+        BigDecimal totalExpenses = transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                userId, TransactionType.EXPENSE, effectiveStartDate, effectiveEndDate);
+
+        int transactionCount = (int) countTransactionsInPeriod(userId, effectiveStartDate, effectiveEndDate);
+        SummaryTotals totals = SummaryTotals.of(totalIncome, totalExpenses, transactionCount);
+
+        // Calculate category breakdown
+        CategoryBreakdown categoryBreakdown = calculateCategoryBreakdown(
+                userId, effectiveStartDate, effectiveEndDate, totalIncome, totalExpenses);
+
+        // Calculate comparison with previous period
+        PeriodComparison comparison = calculatePeriodComparison(
+                userId, effectiveStartDate, effectiveEndDate, totalIncome, totalExpenses);
+
+        return TransactionSummaryResponse.of(period, totals, categoryBreakdown, comparison);
+    }
+
+    // Private helper methods
+
+    private Category validateAndGetCategory(UUID categoryId, TransactionType expectedType) {
+        Category category = categoryService.getCategoryById(categoryId);
+
+        if (category.getType() != expectedType) {
+            throw new CategoryTypeMismatchException(categoryId, expectedType, category.getType());
+        }
+
+        return category;
+    }
+
+    private TransactionListSummary calculateSummaryForFilter(UUID userId, TransactionFilterRequest filter) {
+        // Build specification for sum calculations
+        Specification<Transaction> spec = TransactionSpecification.hasUserId(userId);
+
+        if (filter != null) {
+            if (filter.startDate() != null) {
+                spec = spec.and(TransactionSpecification.dateOnOrAfter(filter.startDate()));
+            }
+            if (filter.endDate() != null) {
+                spec = spec.and(TransactionSpecification.dateOnOrBefore(filter.endDate()));
+            }
+            if (filter.categoryIds() != null && !filter.categoryIds().isEmpty()) {
+                spec = spec.and(TransactionSpecification.hasCategoryIn(filter.categoryIds()));
+            }
+            if (filter.minAmount() != null) {
+                spec = spec.and(TransactionSpecification.amountGreaterThanOrEqual(filter.minAmount()));
+            }
+            if (filter.maxAmount() != null) {
+                spec = spec.and(TransactionSpecification.amountLessThanOrEqual(filter.maxAmount()));
+            }
+            if (filter.search() != null && !filter.search().isBlank()) {
+                spec = spec.and(TransactionSpecification.searchByDescriptionOrNotes(filter.search()));
+            }
+        }
+
+        // Calculate income for filter
+        Specification<Transaction> incomeSpec = spec.and(TransactionSpecification.hasType(TransactionType.INCOME));
+        BigDecimal totalIncome = transactionRepository.findAll(incomeSpec)
+                .stream()
+                .map(Transaction::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        // Calculate expenses for filter
+        Specification<Transaction> expenseSpec = spec.and(TransactionSpecification.hasType(TransactionType.EXPENSE));
+        BigDecimal totalExpenses = transactionRepository.findAll(expenseSpec)
+                .stream()
+                .map(Transaction::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return TransactionListSummary.of(totalIncome, totalExpenses);
+    }
+
+    private long countTransactionsInPeriod(UUID userId, LocalDate startDate, LocalDate endDate) {
+        long incomeCount = transactionRepository.countByUserIdAndTypeAndDateRange(
+                userId, TransactionType.INCOME, startDate, endDate);
+        long expenseCount = transactionRepository.countByUserIdAndTypeAndDateRange(
+                userId, TransactionType.EXPENSE, startDate, endDate);
+        return incomeCount + expenseCount;
+    }
+
+    private CategoryBreakdown calculateCategoryBreakdown(
+            UUID userId,
+            LocalDate startDate,
+            LocalDate endDate,
+            BigDecimal totalIncome,
+            BigDecimal totalExpenses) {
+
+        // Get all transactions in period grouped by category
+        Specification<Transaction> spec = TransactionSpecification.hasUserId(userId)
+                .and(TransactionSpecification.dateOnOrAfter(startDate))
+                .and(TransactionSpecification.dateOnOrBefore(endDate))
+                .and(TransactionSpecification.fetchCategory());
+
+        List<Transaction> transactions = transactionRepository.findAll(spec);
+
+        // Group by category and type
+        Map<UUID, List<Transaction>> incomeByCategory = transactions.stream()
+                .filter(Transaction::isIncome)
+                .collect(Collectors.groupingBy(Transaction::getCategoryId));
+
+        Map<UUID, List<Transaction>> expenseByCategory = transactions.stream()
+                .filter(Transaction::isExpense)
+                .collect(Collectors.groupingBy(Transaction::getCategoryId));
+
+        // Build income breakdown
+        List<CategoryBreakdownItem> incomeBreakdown = buildBreakdownItems(
+                incomeByCategory, totalIncome);
+
+        // Build expense breakdown
+        List<CategoryBreakdownItem> expenseBreakdown = buildBreakdownItems(
+                expenseByCategory, totalExpenses);
+
+        return CategoryBreakdown.of(incomeBreakdown, expenseBreakdown);
+    }
+
+    private List<CategoryBreakdownItem> buildBreakdownItems(
+            Map<UUID, List<Transaction>> transactionsByCategory,
+            BigDecimal total) {
+
+        return transactionsByCategory.entrySet().stream()
+                .map(entry -> {
+                    List<Transaction> txns = entry.getValue();
+                    Category category = txns.get(0).getCategory();
+                    BigDecimal categoryTotal = txns.stream()
+                            .map(Transaction::getAmount)
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+                    BigDecimal percentage = total.compareTo(BigDecimal.ZERO) == 0 ?
+                            BigDecimal.ZERO :
+                            categoryTotal.divide(total, 4, RoundingMode.HALF_UP)
+                                    .multiply(BigDecimal.valueOf(100))
+                                    .setScale(2, RoundingMode.HALF_UP);
+
+                    return CategoryBreakdownItem.of(
+                            CategorySummary.from(category),
+                            categoryTotal,
+                            percentage,
+                            txns.size()
+                    );
+                })
+                .sorted((a, b) -> b.total().compareTo(a.total())) // Sort by total descending
+                .toList();
+    }
+
+    private PeriodComparison calculatePeriodComparison(
+            UUID userId,
+            LocalDate startDate,
+            LocalDate endDate,
+            BigDecimal currentIncome,
+            BigDecimal currentExpenses) {
+
+        // Calculate previous period (same length)
+        long daysBetween = ChronoUnit.DAYS.between(startDate, endDate) + 1;
+        LocalDate prevEndDate = startDate.minusDays(1);
+        LocalDate prevStartDate = prevEndDate.minusDays(daysBetween - 1);
+
+        // Get previous period totals
+        BigDecimal prevIncome = transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                userId, TransactionType.INCOME, prevStartDate, prevEndDate);
+        BigDecimal prevExpenses = transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                userId, TransactionType.EXPENSE, prevStartDate, prevEndDate);
+
+        PreviousPeriodSummary previousPeriod = PreviousPeriodSummary.of(
+                prevStartDate, prevEndDate, prevIncome, prevExpenses);
+
+        // Calculate percentage changes
+        BigDecimal currentNet = currentIncome.subtract(currentExpenses);
+        BigDecimal prevNet = prevIncome.subtract(prevExpenses);
+
+        PeriodChange change = PeriodChange.calculate(
+                currentIncome, prevIncome,
+                currentExpenses, prevExpenses,
+                currentNet, prevNet);
+
+        return PeriodComparison.of(previousPeriod, change);
+    }
+}

--- a/backend/src/main/java/com/pfwa/specification/TransactionSpecification.java
+++ b/backend/src/main/java/com/pfwa/specification/TransactionSpecification.java
@@ -1,0 +1,182 @@
+package com.pfwa.specification;
+
+import com.pfwa.dto.transaction.TransactionFilterRequest;
+import com.pfwa.entity.Transaction;
+import com.pfwa.entity.TransactionType;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * JPA Specification for building dynamic Transaction queries.
+ * Supports filtering by user, date range, type, categories, amount range, and search.
+ */
+public class TransactionSpecification {
+
+    private TransactionSpecification() {
+        // Utility class
+    }
+
+    /**
+     * Creates a specification for filtering transactions by user ID.
+     *
+     * @param userId the user ID
+     * @return the specification
+     */
+    public static Specification<Transaction> hasUserId(UUID userId) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("user").get("id"), userId);
+    }
+
+    /**
+     * Creates a specification for filtering transactions with date on or after start date.
+     *
+     * @param startDate the start date (inclusive)
+     * @return the specification
+     */
+    public static Specification<Transaction> dateOnOrAfter(LocalDate startDate) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThanOrEqualTo(root.get("transactionDate"), startDate);
+    }
+
+    /**
+     * Creates a specification for filtering transactions with date on or before end date.
+     *
+     * @param endDate the end date (inclusive)
+     * @return the specification
+     */
+    public static Specification<Transaction> dateOnOrBefore(LocalDate endDate) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThanOrEqualTo(root.get("transactionDate"), endDate);
+    }
+
+    /**
+     * Creates a specification for filtering transactions by type.
+     *
+     * @param type the transaction type
+     * @return the specification
+     */
+    public static Specification<Transaction> hasType(TransactionType type) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("type"), type);
+    }
+
+    /**
+     * Creates a specification for filtering transactions by category IDs.
+     *
+     * @param categoryIds the list of category IDs
+     * @return the specification
+     */
+    public static Specification<Transaction> hasCategoryIn(List<UUID> categoryIds) {
+        return (root, query, criteriaBuilder) ->
+                root.get("category").get("id").in(categoryIds);
+    }
+
+    /**
+     * Creates a specification for filtering transactions with amount >= minAmount.
+     *
+     * @param minAmount the minimum amount (inclusive)
+     * @return the specification
+     */
+    public static Specification<Transaction> amountGreaterThanOrEqual(BigDecimal minAmount) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThanOrEqualTo(root.get("amount"), minAmount);
+    }
+
+    /**
+     * Creates a specification for filtering transactions with amount <= maxAmount.
+     *
+     * @param maxAmount the maximum amount (inclusive)
+     * @return the specification
+     */
+    public static Specification<Transaction> amountLessThanOrEqual(BigDecimal maxAmount) {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThanOrEqualTo(root.get("amount"), maxAmount);
+    }
+
+    /**
+     * Creates a specification for searching transactions by description or notes.
+     * Case-insensitive partial match.
+     *
+     * @param searchTerm the search term
+     * @return the specification
+     */
+    public static Specification<Transaction> searchByDescriptionOrNotes(String searchTerm) {
+        return (root, query, criteriaBuilder) -> {
+            String pattern = "%" + searchTerm.toLowerCase() + "%";
+            Predicate descriptionMatch = criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("description")), pattern);
+            Predicate notesMatch = criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("notes")), pattern);
+            return criteriaBuilder.or(descriptionMatch, notesMatch);
+        };
+    }
+
+    /**
+     * Builds a combined specification from filter request and user ID.
+     *
+     * @param userId the user ID (required for security)
+     * @param filter the filter request
+     * @return the combined specification
+     */
+    public static Specification<Transaction> fromFilter(UUID userId, TransactionFilterRequest filter) {
+        Specification<Transaction> spec = hasUserId(userId);
+
+        if (filter == null) {
+            return spec;
+        }
+
+        if (filter.startDate() != null) {
+            spec = spec.and(dateOnOrAfter(filter.startDate()));
+        }
+
+        if (filter.endDate() != null) {
+            spec = spec.and(dateOnOrBefore(filter.endDate()));
+        }
+
+        if (filter.type() != null) {
+            spec = spec.and(hasType(filter.type()));
+        }
+
+        if (filter.categoryIds() != null && !filter.categoryIds().isEmpty()) {
+            spec = spec.and(hasCategoryIn(filter.categoryIds()));
+        }
+
+        if (filter.minAmount() != null) {
+            spec = spec.and(amountGreaterThanOrEqual(filter.minAmount()));
+        }
+
+        if (filter.maxAmount() != null) {
+            spec = spec.and(amountLessThanOrEqual(filter.maxAmount()));
+        }
+
+        if (filter.search() != null && !filter.search().isBlank()) {
+            spec = spec.and(searchByDescriptionOrNotes(filter.search()));
+        }
+
+        return spec;
+    }
+
+    /**
+     * Creates a specification for fetching the category eagerly.
+     * Should be used with queries that need category data.
+     *
+     * @return the specification with category fetch
+     */
+    public static Specification<Transaction> fetchCategory() {
+        return (root, query, criteriaBuilder) -> {
+            if (query.getResultType() != Long.class && query.getResultType() != long.class) {
+                root.fetch("category");
+            }
+            return criteriaBuilder.conjunction();
+        };
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -29,6 +29,11 @@ logging:
 
 # App specific dev settings
 app:
+  # Disable secure cookies for HTTP development
+  security:
+    secure-cookies: false
+    cookie-same-site: Lax
+
   # Relaxed rate limits for development
   rate-limit:
     registration:

--- a/backend/src/main/resources/db/migration/V4__create_categories_table.sql
+++ b/backend/src/main/resources/db/migration/V4__create_categories_table.sql
@@ -1,0 +1,59 @@
+-- V4__create_categories_table.sql
+-- Creates the categories table for transaction categorization
+-- Part of Epic 2: Transactions
+
+-- Create enum type for transaction types
+CREATE TYPE transaction_type AS ENUM ('INCOME', 'EXPENSE');
+
+CREATE TABLE categories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL,
+    type transaction_type NOT NULL,
+    icon VARCHAR(50),
+    color VARCHAR(7),
+    display_order INTEGER NOT NULL DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    -- Unique constraint on name and type combination
+    CONSTRAINT categories_name_type_unique UNIQUE (name, type)
+);
+
+-- Index for type lookups (filter categories by type)
+CREATE INDEX idx_categories_type ON categories (type);
+
+-- Index for active categories ordered by display_order
+CREATE INDEX idx_categories_active_order ON categories (display_order)
+    WHERE is_active = TRUE;
+
+-- Comments for documentation
+COMMENT ON TABLE categories IS 'Predefined categories for transaction classification';
+COMMENT ON COLUMN categories.id IS 'Primary key - UUID';
+COMMENT ON COLUMN categories.name IS 'Display name of the category';
+COMMENT ON COLUMN categories.type IS 'Whether this category is for INCOME or EXPENSE transactions';
+COMMENT ON COLUMN categories.icon IS 'Material-UI icon name for display';
+COMMENT ON COLUMN categories.color IS 'Hex color code for display (e.g., #4CAF50)';
+COMMENT ON COLUMN categories.display_order IS 'Order in which to display categories in UI';
+COMMENT ON COLUMN categories.is_active IS 'Whether this category is available for selection';
+COMMENT ON COLUMN categories.created_at IS 'Timestamp when category was created';
+
+-- Seed data for income categories
+INSERT INTO categories (name, type, icon, color, display_order) VALUES
+    ('Salary', 'INCOME', 'payments', '#4CAF50', 1),
+    ('Freelance', 'INCOME', 'work', '#8BC34A', 2),
+    ('Investments', 'INCOME', 'trending_up', '#66BB6A', 3),
+    ('Rental Income', 'INCOME', 'home', '#81C784', 4),
+    ('Other Income', 'INCOME', 'attach_money', '#AED581', 5);
+
+-- Seed data for expense categories
+INSERT INTO categories (name, type, icon, color, display_order) VALUES
+    ('Food & Dining', 'EXPENSE', 'restaurant', '#F44336', 1),
+    ('Transportation', 'EXPENSE', 'directions_car', '#E91E63', 2),
+    ('Housing', 'EXPENSE', 'house', '#9C27B0', 3),
+    ('Utilities', 'EXPENSE', 'bolt', '#673AB7', 4),
+    ('Entertainment', 'EXPENSE', 'movie', '#3F51B5', 5),
+    ('Healthcare', 'EXPENSE', 'local_hospital', '#2196F3', 6),
+    ('Shopping', 'EXPENSE', 'shopping_bag', '#03A9F4', 7),
+    ('Education', 'EXPENSE', 'school', '#00BCD4', 8),
+    ('Personal Care', 'EXPENSE', 'spa', '#009688', 9),
+    ('Other', 'EXPENSE', 'more_horiz', '#607D8B', 10);

--- a/backend/src/main/resources/db/migration/V5__create_transactions_table.sql
+++ b/backend/src/main/resources/db/migration/V5__create_transactions_table.sql
@@ -1,0 +1,78 @@
+-- V5__create_transactions_table.sql
+-- Creates the transactions table for tracking income and expenses
+-- Part of Epic 2: Transactions
+
+CREATE TABLE transactions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    category_id UUID NOT NULL,
+    amount DECIMAL(12, 2) NOT NULL,
+    type transaction_type NOT NULL,
+    transaction_date DATE NOT NULL,
+    description VARCHAR(500),
+    notes TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    -- Amount must be positive
+    CONSTRAINT transactions_amount_positive CHECK (amount > 0),
+
+    -- Amount maximum check (10,000,000)
+    CONSTRAINT transactions_amount_max CHECK (amount <= 10000000),
+
+    -- Foreign key to users table
+    CONSTRAINT fk_transactions_user
+        FOREIGN KEY (user_id)
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    -- Foreign key to categories table
+    CONSTRAINT fk_transactions_category
+        FOREIGN KEY (category_id)
+        REFERENCES categories(id)
+        ON DELETE RESTRICT
+);
+
+-- Primary index for user's transactions (most common query pattern)
+CREATE INDEX idx_transactions_user_id ON transactions (user_id);
+
+-- Index for filtering and sorting by date
+CREATE INDEX idx_transactions_date ON transactions (transaction_date);
+
+-- Index for filtering by category
+CREATE INDEX idx_transactions_category_id ON transactions (category_id);
+
+-- Index for filtering by type
+CREATE INDEX idx_transactions_type ON transactions (type);
+
+-- Composite index for user's transactions sorted by date (pagination)
+CREATE INDEX idx_transactions_user_date ON transactions (user_id, transaction_date DESC);
+
+-- Composite index for user's transactions by type (filtering)
+CREATE INDEX idx_transactions_user_type ON transactions (user_id, type);
+
+-- Composite index for user, date range, and type (common filter combination)
+CREATE INDEX idx_transactions_user_date_type ON transactions (user_id, transaction_date, type);
+
+-- Full-text search index on description for search functionality
+CREATE INDEX idx_transactions_description_search ON transactions
+    USING gin(to_tsvector('english', COALESCE(description, '')));
+
+-- Apply the update_updated_at_column trigger (created in V1)
+CREATE TRIGGER update_transactions_updated_at
+    BEFORE UPDATE ON transactions
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Comments for documentation
+COMMENT ON TABLE transactions IS 'Financial transactions (income and expenses) for users';
+COMMENT ON COLUMN transactions.id IS 'Primary key - UUID';
+COMMENT ON COLUMN transactions.user_id IS 'Reference to the user who owns this transaction';
+COMMENT ON COLUMN transactions.category_id IS 'Reference to the transaction category';
+COMMENT ON COLUMN transactions.amount IS 'Transaction amount (positive decimal, max 10,000,000)';
+COMMENT ON COLUMN transactions.type IS 'Transaction type: INCOME or EXPENSE';
+COMMENT ON COLUMN transactions.transaction_date IS 'Date when the transaction occurred';
+COMMENT ON COLUMN transactions.description IS 'Brief description of the transaction (max 500 chars)';
+COMMENT ON COLUMN transactions.notes IS 'Additional notes about the transaction';
+COMMENT ON COLUMN transactions.created_at IS 'Timestamp when transaction was created';
+COMMENT ON COLUMN transactions.updated_at IS 'Timestamp when transaction was last updated';

--- a/backend/src/main/resources/db/migration/V6__fix_enum_to_varchar.sql
+++ b/backend/src/main/resources/db/migration/V6__fix_enum_to_varchar.sql
@@ -1,0 +1,14 @@
+-- V6__fix_enum_to_varchar.sql
+-- Convert PostgreSQL ENUM types to VARCHAR for JPA compatibility
+-- JPA's @Enumerated(EnumType.STRING) expects VARCHAR, not PostgreSQL ENUM
+
+-- First, alter the categories table to use VARCHAR
+ALTER TABLE categories
+    ALTER COLUMN type TYPE VARCHAR(20) USING type::text;
+
+-- Alter the transactions table (if it exists and uses the enum)
+ALTER TABLE transactions
+    ALTER COLUMN type TYPE VARCHAR(20) USING type::text;
+
+-- Drop the enum type as it's no longer needed
+DROP TYPE IF EXISTS transaction_type;

--- a/backend/src/test/java/com/pfwa/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/pfwa/controller/CategoryControllerTest.java
@@ -1,0 +1,258 @@
+package com.pfwa.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pfwa.dto.transaction.CategoriesResponse;
+import com.pfwa.dto.transaction.CategoryResponse;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.exception.GlobalExceptionHandler;
+import com.pfwa.service.CategoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit tests for CategoryController.
+ * Tests controller behavior with mocked service layer.
+ */
+@ExtendWith(MockitoExtension.class)
+class CategoryControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @InjectMocks
+    private CategoryController categoryController;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(categoryController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    private List<CategoryResponse> createIncomeCategories() {
+        return List.of(
+                new CategoryResponse(UUID.randomUUID(), "Salary", TransactionType.INCOME, "payments", "#4CAF50"),
+                new CategoryResponse(UUID.randomUUID(), "Freelance", TransactionType.INCOME, "work", "#8BC34A"),
+                new CategoryResponse(UUID.randomUUID(), "Investments", TransactionType.INCOME, "trending_up", "#66BB6A")
+        );
+    }
+
+    private List<CategoryResponse> createExpenseCategories() {
+        return List.of(
+                new CategoryResponse(UUID.randomUUID(), "Food & Dining", TransactionType.EXPENSE, "restaurant", "#F44336"),
+                new CategoryResponse(UUID.randomUUID(), "Transportation", TransactionType.EXPENSE, "directions_car", "#E91E63"),
+                new CategoryResponse(UUID.randomUUID(), "Housing", TransactionType.EXPENSE, "home", "#9C27B0"),
+                new CategoryResponse(UUID.randomUUID(), "Utilities", TransactionType.EXPENSE, "bolt", "#673AB7"),
+                new CategoryResponse(UUID.randomUUID(), "Entertainment", TransactionType.EXPENSE, "movie", "#3F51B5")
+        );
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/categories")
+    class GetCategoriesTests {
+
+        @Test
+        @DisplayName("Should return all categories grouped by type")
+        void getCategories_all() throws Exception {
+            // Given
+            List<CategoryResponse> incomeCategories = createIncomeCategories();
+            List<CategoryResponse> expenseCategories = createExpenseCategories();
+            CategoriesResponse response = CategoriesResponse.of(incomeCategories, expenseCategories);
+
+            when(categoryService.getAllCategories()).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories"))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string("Cache-Control", "max-age=3600"))
+                    .andExpect(jsonPath("$.income").isArray())
+                    .andExpect(jsonPath("$.income.length()").value(3))
+                    .andExpect(jsonPath("$.expense").isArray())
+                    .andExpect(jsonPath("$.expense.length()").value(5))
+                    .andExpect(jsonPath("$.income[0].name").value("Salary"))
+                    .andExpect(jsonPath("$.income[0].type").value("INCOME"))
+                    .andExpect(jsonPath("$.expense[0].name").value("Food & Dining"))
+                    .andExpect(jsonPath("$.expense[0].type").value("EXPENSE"));
+
+            verify(categoryService).getAllCategories();
+            verify(categoryService, never()).getCategoriesByType(any());
+        }
+
+        @Test
+        @DisplayName("Should return only income categories when type=INCOME")
+        void getCategories_incomeOnly() throws Exception {
+            // Given
+            List<CategoryResponse> incomeCategories = createIncomeCategories();
+            CategoriesResponse response = CategoriesResponse.of(incomeCategories, Collections.emptyList());
+
+            when(categoryService.getCategoriesByType(TransactionType.INCOME)).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories")
+                            .param("type", "INCOME"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.income").isArray())
+                    .andExpect(jsonPath("$.income.length()").value(3))
+                    .andExpect(jsonPath("$.expense").isArray())
+                    .andExpect(jsonPath("$.expense").isEmpty());
+
+            verify(categoryService).getCategoriesByType(TransactionType.INCOME);
+            verify(categoryService, never()).getAllCategories();
+        }
+
+        @Test
+        @DisplayName("Should return only expense categories when type=EXPENSE")
+        void getCategories_expenseOnly() throws Exception {
+            // Given
+            List<CategoryResponse> expenseCategories = createExpenseCategories();
+            CategoriesResponse response = CategoriesResponse.of(Collections.emptyList(), expenseCategories);
+
+            when(categoryService.getCategoriesByType(TransactionType.EXPENSE)).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories")
+                            .param("type", "EXPENSE"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.income").isArray())
+                    .andExpect(jsonPath("$.income").isEmpty())
+                    .andExpect(jsonPath("$.expense").isArray())
+                    .andExpect(jsonPath("$.expense.length()").value(5));
+
+            verify(categoryService).getCategoriesByType(TransactionType.EXPENSE);
+        }
+
+        @Test
+        @DisplayName("Should return empty lists when no categories exist")
+        void getCategories_empty() throws Exception {
+            // Given
+            CategoriesResponse response = CategoriesResponse.of(Collections.emptyList(), Collections.emptyList());
+            when(categoryService.getAllCategories()).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.income").isEmpty())
+                    .andExpect(jsonPath("$.expense").isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should include category details in response")
+        void getCategories_includesDetails() throws Exception {
+            // Given
+            UUID categoryId = UUID.randomUUID();
+            List<CategoryResponse> incomeCategories = List.of(
+                    new CategoryResponse(categoryId, "Salary", TransactionType.INCOME, "payments", "#4CAF50")
+            );
+            CategoriesResponse response = CategoriesResponse.of(incomeCategories, Collections.emptyList());
+
+            when(categoryService.getAllCategories()).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.income[0].id").value(categoryId.toString()))
+                    .andExpect(jsonPath("$.income[0].name").value("Salary"))
+                    .andExpect(jsonPath("$.income[0].type").value("INCOME"))
+                    .andExpect(jsonPath("$.income[0].icon").value("payments"))
+                    .andExpect(jsonPath("$.income[0].color").value("#4CAF50"));
+        }
+
+        @Test
+        @DisplayName("Should set cache control header for 1 hour")
+        void getCategories_cacheControl() throws Exception {
+            // Given
+            CategoriesResponse response = CategoriesResponse.of(Collections.emptyList(), Collections.emptyList());
+            when(categoryService.getAllCategories()).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories"))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("Cache-Control"))
+                    .andExpect(header().string("Cache-Control", "max-age=3600"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST for invalid type parameter")
+        void getCategories_invalidType() throws Exception {
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories")
+                            .param("type", "INVALID_TYPE"))
+                    .andExpect(status().isBadRequest());
+
+            verify(categoryService, never()).getAllCategories();
+            verify(categoryService, never()).getCategoriesByType(any());
+        }
+
+        @Test
+        @DisplayName("Should return categories ordered by display order")
+        void getCategories_orderedByDisplayOrder() throws Exception {
+            // Given - Categories should be ordered as returned from service
+            List<CategoryResponse> incomeCategories = List.of(
+                    new CategoryResponse(UUID.randomUUID(), "Salary", TransactionType.INCOME, "payments", "#4CAF50"),
+                    new CategoryResponse(UUID.randomUUID(), "Freelance", TransactionType.INCOME, "work", "#8BC34A"),
+                    new CategoryResponse(UUID.randomUUID(), "Investments", TransactionType.INCOME, "trending_up", "#66BB6A")
+            );
+            CategoriesResponse response = CategoriesResponse.of(incomeCategories, Collections.emptyList());
+
+            when(categoryService.getAllCategories()).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.income[0].name").value("Salary"))
+                    .andExpect(jsonPath("$.income[1].name").value("Freelance"))
+                    .andExpect(jsonPath("$.income[2].name").value("Investments"));
+        }
+
+        @Test
+        @DisplayName("Should handle mixed expense categories")
+        void getCategories_expenseVariety() throws Exception {
+            // Given
+            List<CategoryResponse> expenseCategories = List.of(
+                    new CategoryResponse(UUID.randomUUID(), "Food & Dining", TransactionType.EXPENSE, "restaurant", "#F44336"),
+                    new CategoryResponse(UUID.randomUUID(), "Transportation", TransactionType.EXPENSE, "directions_car", "#E91E63"),
+                    new CategoryResponse(UUID.randomUUID(), "Housing", TransactionType.EXPENSE, "home", "#9C27B0"),
+                    new CategoryResponse(UUID.randomUUID(), "Utilities", TransactionType.EXPENSE, "bolt", "#673AB7"),
+                    new CategoryResponse(UUID.randomUUID(), "Entertainment", TransactionType.EXPENSE, "movie", "#3F51B5"),
+                    new CategoryResponse(UUID.randomUUID(), "Healthcare", TransactionType.EXPENSE, "local_hospital", "#2196F3"),
+                    new CategoryResponse(UUID.randomUUID(), "Shopping", TransactionType.EXPENSE, "shopping_bag", "#03A9F4"),
+                    new CategoryResponse(UUID.randomUUID(), "Education", TransactionType.EXPENSE, "school", "#00BCD4"),
+                    new CategoryResponse(UUID.randomUUID(), "Travel", TransactionType.EXPENSE, "flight", "#009688"),
+                    new CategoryResponse(UUID.randomUUID(), "Personal Care", TransactionType.EXPENSE, "spa", "#4CAF50"),
+                    new CategoryResponse(UUID.randomUUID(), "Subscriptions", TransactionType.EXPENSE, "subscriptions", "#8BC34A"),
+                    new CategoryResponse(UUID.randomUUID(), "Other", TransactionType.EXPENSE, "more_horiz", "#CDDC39")
+            );
+            CategoriesResponse response = CategoriesResponse.of(Collections.emptyList(), expenseCategories);
+
+            when(categoryService.getAllCategories()).thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/categories"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.expense.length()").value(12))
+                    .andExpect(jsonPath("$.expense[11].name").value("Other"));
+        }
+    }
+}

--- a/backend/src/test/java/com/pfwa/controller/TransactionControllerIntegrationTest.java
+++ b/backend/src/test/java/com/pfwa/controller/TransactionControllerIntegrationTest.java
@@ -1,0 +1,621 @@
+package com.pfwa.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pfwa.IntegrationTestBase;
+import com.pfwa.dto.transaction.CreateTransactionRequest;
+import com.pfwa.dto.transaction.UpdateTransactionRequest;
+import com.pfwa.entity.Category;
+import com.pfwa.entity.Transaction;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.entity.User;
+import com.pfwa.repository.CategoryRepository;
+import com.pfwa.repository.TransactionRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration tests for Transaction endpoints.
+ * Uses TestContainers for database and tests full request/response cycle.
+ */
+class TransactionControllerIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private User testUser;
+    private Category foodCategory;
+    private Category salaryCategory;
+    private String accessToken;
+
+    @BeforeEach
+    void setUpTransactions() {
+        // Clean up transactions
+        transactionRepository.deleteAll();
+
+        // Create verified user and get access token
+        testUser = createVerifiedUser(TEST_EMAIL, TEST_PASSWORD);
+        accessToken = tokenService.createAccessToken(testUser);
+
+        // Get categories (seeded by Flyway migration)
+        foodCategory = categoryRepository.findByNameAndType("Food & Dining", TransactionType.EXPENSE)
+                .orElseGet(() -> {
+                    Category cat = new Category("Food & Dining", TransactionType.EXPENSE, "restaurant", "#F44336", 1);
+                    cat.setActive(true);
+                    return categoryRepository.save(cat);
+                });
+
+        salaryCategory = categoryRepository.findByNameAndType("Salary", TransactionType.INCOME)
+                .orElseGet(() -> {
+                    Category cat = new Category("Salary", TransactionType.INCOME, "payments", "#4CAF50", 1);
+                    cat.setActive(true);
+                    return categoryRepository.save(cat);
+                });
+    }
+
+    private Transaction createTestTransaction(User user, Category category, BigDecimal amount,
+                                               TransactionType type, LocalDate date, String description) {
+        Transaction transaction = new Transaction(user, category, amount, type, date);
+        transaction.setDescription(description);
+        return transactionRepository.save(transaction);
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/transactions")
+    class CreateTransactionIntegrationTests {
+
+        @Test
+        @DisplayName("Should create transaction with valid data")
+        void createTransaction_success() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    foodCategory.getId(),
+                    LocalDate.of(2026, 1, 20),
+                    "Grocery shopping at Whole Foods",
+                    "Weekly groceries"
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.id").isNotEmpty())
+                    .andExpect(jsonPath("$.amount").value(150.00))
+                    .andExpect(jsonPath("$.type").value("EXPENSE"))
+                    .andExpect(jsonPath("$.category.name").value("Food & Dining"))
+                    .andExpect(jsonPath("$.description").value("Grocery shopping at Whole Foods"))
+                    .andExpect(jsonPath("$.createdAt").isNotEmpty())
+                    .andExpect(jsonPath("$.updatedAt").isNotEmpty());
+
+            // Verify in database
+            List<Transaction> transactions = transactionRepository.findAll();
+            assertThat(transactions).hasSize(1);
+            assertThat(transactions.get(0).getAmount()).isEqualByComparingTo(new BigDecimal("150.00"));
+        }
+
+        @Test
+        @DisplayName("Should create income transaction")
+        void createTransaction_income() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("5000.00"),
+                    TransactionType.INCOME,
+                    salaryCategory.getId(),
+                    LocalDate.of(2026, 1, 15),
+                    "Monthly salary",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.type").value("INCOME"))
+                    .andExpect(jsonPath("$.category.type").value("INCOME"));
+        }
+
+        @Test
+        @DisplayName("Should reject transaction with invalid amount")
+        void createTransaction_invalidAmount() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("-100.00"),
+                    TransactionType.EXPENSE,
+                    foodCategory.getId(),
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+                    .andExpect(jsonPath("$.fieldErrors").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("Should reject transaction with mismatched category type")
+        void createTransaction_categoryTypeMismatch() throws Exception {
+            // Given - Using income category for expense transaction
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("100.00"),
+                    TransactionType.EXPENSE,
+                    salaryCategory.getId(), // Income category
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should reject unauthenticated request")
+        void createTransaction_unauthorized() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("100.00"),
+                    TransactionType.EXPENSE,
+                    foodCategory.getId(),
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/transactions")
+    class GetTransactionsIntegrationTests {
+
+        @Test
+        @DisplayName("Should return paginated transaction list")
+        void getTransactions_success() throws Exception {
+            // Given
+            createTestTransaction(testUser, foodCategory, new BigDecimal("50.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Lunch");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 19), "Dinner");
+            createTestTransaction(testUser, salaryCategory, new BigDecimal("5000.00"),
+                    TransactionType.INCOME, LocalDate.of(2026, 1, 15), "Salary");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.content", hasSize(3)))
+                    .andExpect(jsonPath("$.totalElements").value(3))
+                    .andExpect(jsonPath("$.summary.totalIncome").value(5000.00))
+                    .andExpect(jsonPath("$.summary.totalExpenses").value(150.00));
+        }
+
+        @Test
+        @DisplayName("Should return empty list when no transactions exist")
+        void getTransactions_empty() throws Exception {
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content").isEmpty())
+                    .andExpect(jsonPath("$.totalElements").value(0));
+        }
+
+        @Test
+        @DisplayName("Should filter by date range")
+        void getTransactions_filterByDateRange() throws Exception {
+            // Given
+            createTestTransaction(testUser, foodCategory, new BigDecimal("50.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 10), "Early month");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 20), "Mid month");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("75.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 25), "Late month");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("startDate", "2026-01-15")
+                            .param("endDate", "2026-01-22"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.content[0].description").value("Mid month"));
+        }
+
+        @Test
+        @DisplayName("Should filter by type")
+        void getTransactions_filterByType() throws Exception {
+            // Given
+            createTestTransaction(testUser, foodCategory, new BigDecimal("50.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Expense");
+            createTestTransaction(testUser, salaryCategory, new BigDecimal("5000.00"),
+                    TransactionType.INCOME, LocalDate.of(2026, 1, 15), "Income");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("type", "EXPENSE"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.content[0].type").value("EXPENSE"));
+        }
+
+        @Test
+        @DisplayName("Should filter by category")
+        void getTransactions_filterByCategory() throws Exception {
+            // Given
+            createTestTransaction(testUser, foodCategory, new BigDecimal("50.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Food expense");
+            createTestTransaction(testUser, salaryCategory, new BigDecimal("5000.00"),
+                    TransactionType.INCOME, LocalDate.of(2026, 1, 15), "Salary income");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("categoryIds", foodCategory.getId().toString()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.content[0].category.name").value("Food & Dining"));
+        }
+
+        @Test
+        @DisplayName("Should filter by amount range")
+        void getTransactions_filterByAmountRange() throws Exception {
+            // Given
+            createTestTransaction(testUser, foodCategory, new BigDecimal("25.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Small");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 19), "Medium");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("500.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 20), "Large");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("minAmount", "50")
+                            .param("maxAmount", "200"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.content[0].amount").value(100.00));
+        }
+
+        @Test
+        @DisplayName("Should search by description")
+        void getTransactions_search() throws Exception {
+            // Given
+            createTestTransaction(testUser, foodCategory, new BigDecimal("50.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Grocery shopping");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("75.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 19), "Restaurant dinner");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("30.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 20), "Groceries at Costco");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("search", "grocery"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(2)));
+        }
+
+        @Test
+        @DisplayName("Should sort by amount descending")
+        void getTransactions_sortByAmount() throws Exception {
+            // Given
+            createTestTransaction(testUser, foodCategory, new BigDecimal("50.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Small");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("200.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 19), "Large");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 20), "Medium");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("sort", "amount,desc"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content[0].amount").value(200.00))
+                    .andExpect(jsonPath("$.content[1].amount").value(100.00))
+                    .andExpect(jsonPath("$.content[2].amount").value(50.00));
+        }
+
+        @Test
+        @DisplayName("Should paginate results")
+        void getTransactions_pagination() throws Exception {
+            // Given - Create 25 transactions
+            for (int i = 0; i < 25; i++) {
+                createTestTransaction(testUser, foodCategory, new BigDecimal(10 + i),
+                        TransactionType.EXPENSE, LocalDate.of(2026, 1, 1).plusDays(i), "Transaction " + i);
+            }
+
+            // When/Then - First page
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("page", "0")
+                            .param("size", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(10)))
+                    .andExpect(jsonPath("$.totalElements").value(25))
+                    .andExpect(jsonPath("$.totalPages").value(3));
+        }
+
+        @Test
+        @DisplayName("Should not return transactions of other users")
+        void getTransactions_userIsolation() throws Exception {
+            // Given
+            User otherUser = createVerifiedUser("other@example.com", TEST_PASSWORD);
+            createTestTransaction(testUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "My transaction");
+            createTestTransaction(otherUser, foodCategory, new BigDecimal("200.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 19), "Other user transaction");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content", hasSize(1)))
+                    .andExpect(jsonPath("$.content[0].description").value("My transaction"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/transactions/{id}")
+    class GetTransactionByIdIntegrationTests {
+
+        @Test
+        @DisplayName("Should return transaction by ID")
+        void getTransaction_success() throws Exception {
+            // Given
+            Transaction transaction = createTestTransaction(testUser, foodCategory, new BigDecimal("150.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 20), "Test transaction");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/{id}", transaction.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(transaction.getId().toString()))
+                    .andExpect(jsonPath("$.amount").value(150.00))
+                    .andExpect(jsonPath("$.description").value("Test transaction"));
+        }
+
+        @Test
+        @DisplayName("Should return 404 for non-existent transaction")
+        void getTransaction_notFound() throws Exception {
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/{id}", UUID.randomUUID())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("Should return 404 when accessing other user's transaction")
+        void getTransaction_otherUser() throws Exception {
+            // Given
+            User otherUser = createVerifiedUser("other@example.com", TEST_PASSWORD);
+            Transaction otherTransaction = createTestTransaction(otherUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Other user transaction");
+
+            // When/Then - Current user cannot access other user's transaction
+            mockMvc.perform(get("/api/v1/transactions/{id}", otherTransaction.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/transactions/{id}")
+    class UpdateTransactionIntegrationTests {
+
+        @Test
+        @DisplayName("Should update transaction successfully")
+        void updateTransaction_success() throws Exception {
+            // Given
+            Transaction transaction = createTestTransaction(testUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Original description");
+
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    foodCategory.getId(),
+                    LocalDate.of(2026, 1, 19),
+                    "Updated description",
+                    "Updated notes"
+            );
+
+            // When/Then
+            mockMvc.perform(put("/api/v1/transactions/{id}", transaction.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.amount").value(150.00))
+                    .andExpect(jsonPath("$.description").value("Updated description"))
+                    .andExpect(jsonPath("$.notes").value("Updated notes"));
+
+            // Verify in database
+            Transaction updated = transactionRepository.findById(transaction.getId()).orElseThrow();
+            assertThat(updated.getAmount()).isEqualByComparingTo(new BigDecimal("150.00"));
+            assertThat(updated.getDescription()).isEqualTo("Updated description");
+        }
+
+        @Test
+        @DisplayName("Should return 404 when updating non-existent transaction")
+        void updateTransaction_notFound() throws Exception {
+            // Given
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    foodCategory.getId(),
+                    LocalDate.of(2026, 1, 19),
+                    "Updated",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(put("/api/v1/transactions/{id}", UUID.randomUUID())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("Should not allow updating other user's transaction")
+        void updateTransaction_otherUser() throws Exception {
+            // Given
+            User otherUser = createVerifiedUser("other@example.com", TEST_PASSWORD);
+            Transaction otherTransaction = createTestTransaction(otherUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Other transaction");
+
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("999.00"),
+                    TransactionType.EXPENSE,
+                    foodCategory.getId(),
+                    LocalDate.of(2026, 1, 19),
+                    "Hacked",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(put("/api/v1/transactions/{id}", otherTransaction.getId())
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound());
+
+            // Verify original is unchanged
+            Transaction unchanged = transactionRepository.findById(otherTransaction.getId()).orElseThrow();
+            assertThat(unchanged.getAmount()).isEqualByComparingTo(new BigDecimal("100.00"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/transactions/{id}")
+    class DeleteTransactionIntegrationTests {
+
+        @Test
+        @DisplayName("Should delete transaction successfully")
+        void deleteTransaction_success() throws Exception {
+            // Given
+            Transaction transaction = createTestTransaction(testUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "To be deleted");
+
+            // When/Then
+            mockMvc.perform(delete("/api/v1/transactions/{id}", transaction.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNoContent());
+
+            // Verify deletion
+            assertThat(transactionRepository.findById(transaction.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should return 404 when deleting non-existent transaction")
+        void deleteTransaction_notFound() throws Exception {
+            // When/Then
+            mockMvc.perform(delete("/api/v1/transactions/{id}", UUID.randomUUID())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("Should not allow deleting other user's transaction")
+        void deleteTransaction_otherUser() throws Exception {
+            // Given
+            User otherUser = createVerifiedUser("other@example.com", TEST_PASSWORD);
+            Transaction otherTransaction = createTestTransaction(otherUser, foodCategory, new BigDecimal("100.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Other transaction");
+
+            // When/Then
+            mockMvc.perform(delete("/api/v1/transactions/{id}", otherTransaction.getId())
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isNotFound());
+
+            // Verify not deleted
+            assertThat(transactionRepository.findById(otherTransaction.getId())).isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/transactions/summary")
+    class GetSummaryIntegrationTests {
+
+        @Test
+        @DisplayName("Should return transaction summary")
+        void getSummary_success() throws Exception {
+            // Given
+            createTestTransaction(testUser, salaryCategory, new BigDecimal("5000.00"),
+                    TransactionType.INCOME, LocalDate.of(2026, 1, 15), "Salary");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("500.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 18), "Food");
+            createTestTransaction(testUser, foodCategory, new BigDecimal("200.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 20), "More food");
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/summary")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("startDate", "2026-01-01")
+                            .param("endDate", "2026-01-31"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.totals.income").value(5000.00))
+                    .andExpect(jsonPath("$.totals.expenses").value(700.00))
+                    .andExpect(jsonPath("$.totals.net").value(4300.00))
+                    .andExpect(jsonPath("$.totals.transactionCount").value(3));
+        }
+
+        @Test
+        @DisplayName("Should return zero totals when no transactions")
+        void getSummary_noTransactions() throws Exception {
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/summary")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .param("startDate", "2026-01-01")
+                            .param("endDate", "2026-01-31"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.totals.income").value(0))
+                    .andExpect(jsonPath("$.totals.expenses").value(0))
+                    .andExpect(jsonPath("$.totals.net").value(0));
+        }
+    }
+}

--- a/backend/src/test/java/com/pfwa/controller/TransactionControllerTest.java
+++ b/backend/src/test/java/com/pfwa/controller/TransactionControllerTest.java
@@ -1,0 +1,885 @@
+package com.pfwa.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pfwa.dto.transaction.*;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.exception.CategoryNotFoundException;
+import com.pfwa.exception.CategoryTypeMismatchException;
+import com.pfwa.exception.GlobalExceptionHandler;
+import com.pfwa.exception.TransactionNotFoundException;
+import com.pfwa.security.UserPrincipal;
+import com.pfwa.service.TransactionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit tests for TransactionController.
+ * Tests controller behavior with mocked service layer.
+ */
+@ExtendWith(MockitoExtension.class)
+class TransactionControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @InjectMocks
+    private TransactionController transactionController;
+
+    private ObjectMapper objectMapper;
+    private UUID testUserId;
+    private UUID testTransactionId;
+    private UUID testCategoryId;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        mockMvc = MockMvcBuilders.standaloneSetup(transactionController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new TestUserPrincipalArgumentResolver())
+                .build();
+
+        testUserId = UUID.randomUUID();
+        testTransactionId = UUID.randomUUID();
+        testCategoryId = UUID.randomUUID();
+    }
+
+    private TransactionResponse createTestTransactionResponse() {
+        CategoryResponse category = new CategoryResponse(
+                testCategoryId,
+                "Food & Dining",
+                TransactionType.EXPENSE,
+                "restaurant",
+                "#F44336"
+        );
+        return new TransactionResponse(
+                testTransactionId,
+                new BigDecimal("150.00"),
+                TransactionType.EXPENSE,
+                category,
+                LocalDate.of(2026, 1, 20),
+                "Grocery shopping",
+                "Weekly groceries",
+                Instant.now(),
+                Instant.now()
+        );
+    }
+
+    private TransactionListResponse createTestTransactionListResponse() {
+        TransactionListSummary summary = TransactionListSummary.of(
+                new BigDecimal("5000.00"),
+                new BigDecimal("3250.50")
+        );
+        AppliedFilters filters = AppliedFilters.from(TransactionFilterRequest.empty());
+        return TransactionListResponse.of(
+                List.of(createTestTransactionResponse()),
+                0, 20, 1, 1, true, true,
+                summary,
+                filters
+        );
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/transactions")
+    class CreateTransactionTests {
+
+        @Test
+        @DisplayName("Should return 201 CREATED on successful transaction creation")
+        void createTransaction_success() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Grocery shopping",
+                    "Weekly groceries"
+            );
+
+            TransactionResponse response = createTestTransactionResponse();
+            when(transactionService.createTransaction(any(UUID.class), any(CreateTransactionRequest.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.id").value(testTransactionId.toString()))
+                    .andExpect(jsonPath("$.amount").value(150.00))
+                    .andExpect(jsonPath("$.type").value("EXPENSE"))
+                    .andExpect(jsonPath("$.category.name").value("Food & Dining"))
+                    .andExpect(jsonPath("$.description").value("Grocery shopping"));
+
+            verify(transactionService).createTransaction(any(UUID.class), any(CreateTransactionRequest.class));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when amount is missing")
+        void createTransaction_missingAmount() throws Exception {
+            // Given
+            String requestJson = """
+                    {
+                        "type": "EXPENSE",
+                        "categoryId": "%s",
+                        "date": "2026-01-20",
+                        "description": "Test"
+                    }
+                    """.formatted(testCategoryId);
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+
+            verify(transactionService, never()).createTransaction(any(), any());
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when amount is zero")
+        void createTransaction_zeroAmount() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    BigDecimal.ZERO,
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+
+            verify(transactionService, never()).createTransaction(any(), any());
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when amount is negative")
+        void createTransaction_negativeAmount() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("-100.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when amount exceeds maximum")
+        void createTransaction_amountExceedsMax() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("10000001"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when type is missing")
+        void createTransaction_missingType() throws Exception {
+            // Given
+            String requestJson = """
+                    {
+                        "amount": 150.00,
+                        "categoryId": "%s",
+                        "date": "2026-01-20"
+                    }
+                    """.formatted(testCategoryId);
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when categoryId is missing")
+        void createTransaction_missingCategoryId() throws Exception {
+            // Given
+            String requestJson = """
+                    {
+                        "amount": 150.00,
+                        "type": "EXPENSE",
+                        "date": "2026-01-20"
+                    }
+                    """;
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when date is missing")
+        void createTransaction_missingDate() throws Exception {
+            // Given
+            String requestJson = """
+                    {
+                        "amount": 150.00,
+                        "type": "EXPENSE",
+                        "categoryId": "%s"
+                    }
+                    """.formatted(testCategoryId);
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestJson))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when description exceeds 500 characters")
+        void createTransaction_descriptionTooLong() throws Exception {
+            // Given
+            String longDescription = "a".repeat(501);
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    longDescription,
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should return 404 NOT FOUND when category does not exist")
+        void createTransaction_categoryNotFound() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            when(transactionService.createTransaction(any(UUID.class), any(CreateTransactionRequest.class)))
+                    .thenThrow(new CategoryNotFoundException(testCategoryId));
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST when category type mismatches transaction type")
+        void createTransaction_categoryTypeMismatch() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            when(transactionService.createTransaction(any(UUID.class), any(CreateTransactionRequest.class)))
+                    .thenThrow(new CategoryTypeMismatchException(testCategoryId, TransactionType.EXPENSE, TransactionType.INCOME));
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+        }
+
+        @Test
+        @DisplayName("Should accept transaction with null description and notes")
+        void createTransaction_nullOptionalFields() throws Exception {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    null,
+                    null
+            );
+
+            TransactionResponse response = createTestTransactionResponse();
+            when(transactionService.createTransaction(any(UUID.class), any(CreateTransactionRequest.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated());
+
+            verify(transactionService).createTransaction(any(UUID.class), any(CreateTransactionRequest.class));
+        }
+
+        @Test
+        @DisplayName("Should accept transaction with INCOME type")
+        void createTransaction_incomeType() throws Exception {
+            // Given
+            UUID incomeCategoryId = UUID.randomUUID();
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("5000.00"),
+                    TransactionType.INCOME,
+                    incomeCategoryId,
+                    LocalDate.of(2026, 1, 15),
+                    "Monthly salary",
+                    null
+            );
+
+            CategoryResponse category = new CategoryResponse(
+                    incomeCategoryId, "Salary", TransactionType.INCOME, "payments", "#4CAF50"
+            );
+            TransactionResponse response = new TransactionResponse(
+                    testTransactionId, new BigDecimal("5000.00"), TransactionType.INCOME,
+                    category, LocalDate.of(2026, 1, 15), "Monthly salary", null,
+                    Instant.now(), Instant.now()
+            );
+            when(transactionService.createTransaction(any(UUID.class), any(CreateTransactionRequest.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(post("/api/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.type").value("INCOME"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/transactions")
+    class GetTransactionsTests {
+
+        @Test
+        @DisplayName("Should return paginated transaction list")
+        void getTransactions_success() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content").isArray())
+                    .andExpect(jsonPath("$.content.length()").value(1))
+                    .andExpect(jsonPath("$.totalElements").value(1))
+                    .andExpect(jsonPath("$.summary.totalIncome").value(5000.00))
+                    .andExpect(jsonPath("$.summary.totalExpenses").value(3250.50));
+
+            verify(transactionService).getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should apply pagination parameters")
+        void getTransactions_withPagination() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("page", "2")
+                            .param("size", "50"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), any(TransactionFilterRequest.class), argThat(pageable ->
+                    pageable.getPageNumber() == 2 && pageable.getPageSize() == 50
+            ));
+        }
+
+        @Test
+        @DisplayName("Should constrain page size to maximum 100")
+        void getTransactions_maxPageSize() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("size", "200"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), any(TransactionFilterRequest.class), argThat(pageable ->
+                    pageable.getPageSize() == 100
+            ));
+        }
+
+        @Test
+        @DisplayName("Should apply date filter")
+        void getTransactions_withDateFilter() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("startDate", "2026-01-01")
+                            .param("endDate", "2026-01-31"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), argThat(filter ->
+                    filter.startDate() != null && filter.endDate() != null
+            ), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should apply type filter")
+        void getTransactions_withTypeFilter() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("type", "EXPENSE"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), argThat(filter ->
+                    filter.type() == TransactionType.EXPENSE
+            ), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should apply category filter")
+        void getTransactions_withCategoryFilter() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            UUID categoryId1 = UUID.randomUUID();
+            UUID categoryId2 = UUID.randomUUID();
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("categoryIds", categoryId1.toString(), categoryId2.toString()))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), argThat(filter ->
+                    filter.categoryIds() != null && filter.categoryIds().size() == 2
+            ), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should apply amount range filter")
+        void getTransactions_withAmountFilter() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("minAmount", "50")
+                            .param("maxAmount", "200"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), argThat(filter ->
+                    filter.minAmount() != null && filter.minAmount().compareTo(new BigDecimal("50")) == 0 &&
+                    filter.maxAmount() != null && filter.maxAmount().compareTo(new BigDecimal("200")) == 0
+            ), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should apply search filter")
+        void getTransactions_withSearch() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("search", "grocery"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), argThat(filter ->
+                    "grocery".equals(filter.search())
+            ), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("Should apply sort parameters")
+        void getTransactions_withSort() throws Exception {
+            // Given
+            TransactionListResponse response = createTestTransactionListResponse();
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions")
+                            .param("sort", "amount,asc"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactions(any(UUID.class), any(TransactionFilterRequest.class), argThat(pageable ->
+                    pageable.getSort().getOrderFor("amount") != null &&
+                    pageable.getSort().getOrderFor("amount").isAscending()
+            ));
+        }
+
+        @Test
+        @DisplayName("Should return empty list when no transactions")
+        void getTransactions_emptyList() throws Exception {
+            // Given
+            TransactionListSummary summary = TransactionListSummary.of(BigDecimal.ZERO, BigDecimal.ZERO);
+            AppliedFilters filters = AppliedFilters.from(TransactionFilterRequest.empty());
+            TransactionListResponse response = TransactionListResponse.of(
+                    Collections.emptyList(), 0, 20, 0, 0, true, true, summary, filters
+            );
+            when(transactionService.getTransactions(any(UUID.class), any(TransactionFilterRequest.class), any(Pageable.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.content").isEmpty())
+                    .andExpect(jsonPath("$.totalElements").value(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/transactions/{id}")
+    class GetTransactionByIdTests {
+
+        @Test
+        @DisplayName("Should return transaction by ID")
+        void getTransaction_success() throws Exception {
+            // Given
+            TransactionResponse response = createTestTransactionResponse();
+            when(transactionService.getTransaction(any(UUID.class), any(UUID.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/{id}", testTransactionId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(testTransactionId.toString()))
+                    .andExpect(jsonPath("$.amount").value(150.00));
+
+            verify(transactionService).getTransaction(any(UUID.class), eq(testTransactionId));
+        }
+
+        @Test
+        @DisplayName("Should return 404 NOT FOUND when transaction does not exist")
+        void getTransaction_notFound() throws Exception {
+            // Given
+            when(transactionService.getTransaction(any(UUID.class), any(UUID.class)))
+                    .thenThrow(new TransactionNotFoundException(testTransactionId));
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/{id}", testTransactionId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST for invalid UUID format")
+        void getTransaction_invalidUuid() throws Exception {
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/{id}", "invalid-uuid"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/transactions/{id}")
+    class UpdateTransactionTests {
+
+        @Test
+        @DisplayName("Should return 200 OK on successful update")
+        void updateTransaction_success() throws Exception {
+            // Given
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("175.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Updated description",
+                    "Updated notes"
+            );
+
+            TransactionResponse response = createTestTransactionResponse();
+            when(transactionService.updateTransaction(any(UUID.class), any(UUID.class), any(UpdateTransactionRequest.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(put("/api/v1/transactions/{id}", testTransactionId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(testTransactionId.toString()));
+
+            verify(transactionService).updateTransaction(any(UUID.class), eq(testTransactionId), any(UpdateTransactionRequest.class));
+        }
+
+        @Test
+        @DisplayName("Should return 404 NOT FOUND when updating non-existent transaction")
+        void updateTransaction_notFound() throws Exception {
+            // Given
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("175.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Updated",
+                    null
+            );
+
+            when(transactionService.updateTransaction(any(UUID.class), any(UUID.class), any(UpdateTransactionRequest.class)))
+                    .thenThrow(new TransactionNotFoundException(testTransactionId));
+
+            // When/Then
+            mockMvc.perform(put("/api/v1/transactions/{id}", testTransactionId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST for invalid update data")
+        void updateTransaction_invalidData() throws Exception {
+            // Given
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("-100.00"), // Invalid negative amount
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            // When/Then
+            mockMvc.perform(put("/api/v1/transactions/{id}", testTransactionId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"));
+
+            verify(transactionService, never()).updateTransaction(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("Should allow changing transaction type")
+        void updateTransaction_changeType() throws Exception {
+            // Given
+            UUID incomeCategoryId = UUID.randomUUID();
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("100.00"),
+                    TransactionType.INCOME,
+                    incomeCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Changed to income",
+                    null
+            );
+
+            CategoryResponse category = new CategoryResponse(
+                    incomeCategoryId, "Refunds", TransactionType.INCOME, "receipt", "#9CCC65"
+            );
+            TransactionResponse response = new TransactionResponse(
+                    testTransactionId, new BigDecimal("100.00"), TransactionType.INCOME,
+                    category, LocalDate.of(2026, 1, 20), "Changed to income", null,
+                    Instant.now(), Instant.now()
+            );
+            when(transactionService.updateTransaction(any(UUID.class), any(UUID.class), any(UpdateTransactionRequest.class)))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(put("/api/v1/transactions/{id}", testTransactionId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.type").value("INCOME"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/transactions/{id}")
+    class DeleteTransactionTests {
+
+        @Test
+        @DisplayName("Should return 204 NO CONTENT on successful deletion")
+        void deleteTransaction_success() throws Exception {
+            // Given
+            doNothing().when(transactionService).deleteTransaction(any(UUID.class), any(UUID.class));
+
+            // When/Then
+            mockMvc.perform(delete("/api/v1/transactions/{id}", testTransactionId))
+                    .andExpect(status().isNoContent());
+
+            verify(transactionService).deleteTransaction(any(UUID.class), eq(testTransactionId));
+        }
+
+        @Test
+        @DisplayName("Should return 404 NOT FOUND when deleting non-existent transaction")
+        void deleteTransaction_notFound() throws Exception {
+            // Given
+            doThrow(new TransactionNotFoundException(testTransactionId))
+                    .when(transactionService).deleteTransaction(any(UUID.class), any(UUID.class));
+
+            // When/Then
+            mockMvc.perform(delete("/api/v1/transactions/{id}", testTransactionId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.error").value("NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("Should return 400 BAD REQUEST for invalid UUID format")
+        void deleteTransaction_invalidUuid() throws Exception {
+            // When/Then
+            mockMvc.perform(delete("/api/v1/transactions/{id}", "not-a-uuid"))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/transactions/summary")
+    class GetTransactionSummaryTests {
+
+        @Test
+        @DisplayName("Should return transaction summary")
+        void getSummary_success() throws Exception {
+            // Given
+            SummaryPeriod period = SummaryPeriod.of(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31));
+            SummaryTotals totals = SummaryTotals.of(new BigDecimal("5000.00"), new BigDecimal("3250.50"), 87);
+            CategoryBreakdown breakdown = CategoryBreakdown.of(Collections.emptyList(), Collections.emptyList());
+            TransactionSummaryResponse response = TransactionSummaryResponse.of(period, totals, breakdown, null);
+
+            when(transactionService.getTransactionSummary(any(UUID.class), any(), any()))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/summary")
+                            .param("startDate", "2026-01-01")
+                            .param("endDate", "2026-01-31"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.totals.income").value(5000.00))
+                    .andExpect(jsonPath("$.totals.expenses").value(3250.50))
+                    .andExpect(jsonPath("$.totals.transactionCount").value(87));
+
+            verify(transactionService).getTransactionSummary(
+                    any(UUID.class),
+                    eq(LocalDate.of(2026, 1, 1)),
+                    eq(LocalDate.of(2026, 1, 31))
+            );
+        }
+
+        @Test
+        @DisplayName("Should return summary without date parameters")
+        void getSummary_noDates() throws Exception {
+            // Given
+            SummaryPeriod period = SummaryPeriod.of(LocalDate.now().withDayOfMonth(1), LocalDate.now());
+            SummaryTotals totals = SummaryTotals.of(BigDecimal.ZERO, BigDecimal.ZERO, 0);
+            CategoryBreakdown breakdown = CategoryBreakdown.of(Collections.emptyList(), Collections.emptyList());
+            TransactionSummaryResponse response = TransactionSummaryResponse.of(period, totals, breakdown, null);
+
+            when(transactionService.getTransactionSummary(any(UUID.class), isNull(), isNull()))
+                    .thenReturn(response);
+
+            // When/Then
+            mockMvc.perform(get("/api/v1/transactions/summary"))
+                    .andExpect(status().isOk());
+
+            verify(transactionService).getTransactionSummary(any(UUID.class), isNull(), isNull());
+        }
+    }
+
+    /**
+     * Custom argument resolver for tests to inject UserPrincipal
+     */
+    static class TestUserPrincipalArgumentResolver implements org.springframework.web.method.support.HandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(org.springframework.core.MethodParameter parameter) {
+            return parameter.getParameterType().equals(UserPrincipal.class);
+        }
+
+        @Override
+        public Object resolveArgument(org.springframework.core.MethodParameter parameter,
+                                       org.springframework.web.method.support.ModelAndViewContainer mavContainer,
+                                       org.springframework.web.context.request.NativeWebRequest webRequest,
+                                       org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+            return mock(UserPrincipal.class, invocation -> {
+                if (invocation.getMethod().getName().equals("getId")) {
+                    return UUID.randomUUID();
+                }
+                return null;
+            });
+        }
+    }
+}

--- a/backend/src/test/java/com/pfwa/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/pfwa/service/CategoryServiceTest.java
@@ -1,0 +1,362 @@
+package com.pfwa.service;
+
+import com.pfwa.dto.transaction.CategoriesResponse;
+import com.pfwa.dto.transaction.CategoryResponse;
+import com.pfwa.entity.Category;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.exception.CategoryNotFoundException;
+import com.pfwa.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for CategoryService.
+ * Tests business logic with mocked repository.
+ */
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    private Category salaryCategory;
+    private Category freelanceCategory;
+    private Category foodCategory;
+    private Category transportCategory;
+
+    @BeforeEach
+    void setUp() {
+        salaryCategory = createCategory("Salary", TransactionType.INCOME, "payments", "#4CAF50", 1);
+        freelanceCategory = createCategory("Freelance", TransactionType.INCOME, "work", "#8BC34A", 2);
+        foodCategory = createCategory("Food & Dining", TransactionType.EXPENSE, "restaurant", "#F44336", 1);
+        transportCategory = createCategory("Transportation", TransactionType.EXPENSE, "directions_car", "#E91E63", 2);
+    }
+
+    private Category createCategory(String name, TransactionType type, String icon, String color, int displayOrder) {
+        Category category = new Category(name, type, icon, color, displayOrder);
+        setField(category, "id", UUID.randomUUID());
+        category.setActive(true);
+        return category;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field: " + fieldName, e);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllCategories")
+    class GetAllCategoriesTests {
+
+        @Test
+        @DisplayName("Should return all categories grouped by type")
+        void getAllCategories_success() {
+            // Given
+            when(categoryRepository.findAllIncomeCategories())
+                    .thenReturn(List.of(salaryCategory, freelanceCategory));
+            when(categoryRepository.findAllExpenseCategories())
+                    .thenReturn(List.of(foodCategory, transportCategory));
+
+            // When
+            CategoriesResponse result = categoryService.getAllCategories();
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.income()).hasSize(2);
+            assertThat(result.expense()).hasSize(2);
+            assertThat(result.income().get(0).name()).isEqualTo("Salary");
+            assertThat(result.expense().get(0).name()).isEqualTo("Food & Dining");
+        }
+
+        @Test
+        @DisplayName("Should return empty lists when no categories exist")
+        void getAllCategories_empty() {
+            // Given
+            when(categoryRepository.findAllIncomeCategories()).thenReturn(Collections.emptyList());
+            when(categoryRepository.findAllExpenseCategories()).thenReturn(Collections.emptyList());
+
+            // When
+            CategoriesResponse result = categoryService.getAllCategories();
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.income()).isEmpty();
+            assertThat(result.expense()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should return only income categories when no expense categories exist")
+        void getAllCategories_onlyIncome() {
+            // Given
+            when(categoryRepository.findAllIncomeCategories())
+                    .thenReturn(List.of(salaryCategory, freelanceCategory));
+            when(categoryRepository.findAllExpenseCategories())
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            CategoriesResponse result = categoryService.getAllCategories();
+
+            // Then
+            assertThat(result.income()).hasSize(2);
+            assertThat(result.expense()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should return only expense categories when no income categories exist")
+        void getAllCategories_onlyExpense() {
+            // Given
+            when(categoryRepository.findAllIncomeCategories())
+                    .thenReturn(Collections.emptyList());
+            when(categoryRepository.findAllExpenseCategories())
+                    .thenReturn(List.of(foodCategory, transportCategory));
+
+            // When
+            CategoriesResponse result = categoryService.getAllCategories();
+
+            // Then
+            assertThat(result.income()).isEmpty();
+            assertThat(result.expense()).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCategoriesByType")
+    class GetCategoriesByTypeTests {
+
+        @Test
+        @DisplayName("Should return income categories when type is INCOME")
+        void getCategoriesByType_income() {
+            // Given
+            when(categoryRepository.findByTypeAndActiveOrderByDisplayOrder(TransactionType.INCOME))
+                    .thenReturn(List.of(salaryCategory, freelanceCategory));
+
+            // When
+            CategoriesResponse result = categoryService.getCategoriesByType(TransactionType.INCOME);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.income()).hasSize(2);
+            assertThat(result.expense()).isEmpty();
+            assertThat(result.income().get(0).type()).isEqualTo(TransactionType.INCOME);
+        }
+
+        @Test
+        @DisplayName("Should return expense categories when type is EXPENSE")
+        void getCategoriesByType_expense() {
+            // Given
+            when(categoryRepository.findByTypeAndActiveOrderByDisplayOrder(TransactionType.EXPENSE))
+                    .thenReturn(List.of(foodCategory, transportCategory));
+
+            // When
+            CategoriesResponse result = categoryService.getCategoriesByType(TransactionType.EXPENSE);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.income()).isEmpty();
+            assertThat(result.expense()).hasSize(2);
+            assertThat(result.expense().get(0).type()).isEqualTo(TransactionType.EXPENSE);
+        }
+
+        @Test
+        @DisplayName("Should return all categories when type is null")
+        void getCategoriesByType_null() {
+            // Given
+            when(categoryRepository.findAllIncomeCategories())
+                    .thenReturn(List.of(salaryCategory));
+            when(categoryRepository.findAllExpenseCategories())
+                    .thenReturn(List.of(foodCategory));
+
+            // When
+            CategoriesResponse result = categoryService.getCategoriesByType(null);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.income()).hasSize(1);
+            assertThat(result.expense()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("Should return empty list when no categories of type exist")
+        void getCategoriesByType_empty() {
+            // Given
+            when(categoryRepository.findByTypeAndActiveOrderByDisplayOrder(TransactionType.INCOME))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            CategoriesResponse result = categoryService.getCategoriesByType(TransactionType.INCOME);
+
+            // Then
+            assertThat(result.income()).isEmpty();
+            assertThat(result.expense()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getCategoryById")
+    class GetCategoryByIdTests {
+
+        @Test
+        @DisplayName("Should return category when it exists and is active")
+        void getCategoryById_success() {
+            // Given
+            UUID categoryId = salaryCategory.getId();
+            when(categoryRepository.findByIdAndActive(categoryId))
+                    .thenReturn(Optional.of(salaryCategory));
+
+            // When
+            Category result = categoryService.getCategoryById(categoryId);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getName()).isEqualTo("Salary");
+            assertThat(result.getType()).isEqualTo(TransactionType.INCOME);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when category does not exist")
+        void getCategoryById_notFound() {
+            // Given
+            UUID categoryId = UUID.randomUUID();
+            when(categoryRepository.findByIdAndActive(categoryId))
+                    .thenReturn(Optional.empty());
+
+            // When/Then
+            assertThatThrownBy(() -> categoryService.getCategoryById(categoryId))
+                    .isInstanceOf(CategoryNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when category is inactive")
+        void getCategoryById_inactive() {
+            // Given
+            Category inactiveCategory = createCategory("Old Category", TransactionType.EXPENSE, "old", "#000000", 99);
+            inactiveCategory.setActive(false);
+            UUID categoryId = inactiveCategory.getId();
+
+            when(categoryRepository.findByIdAndActive(categoryId))
+                    .thenReturn(Optional.empty()); // Inactive categories are not returned
+
+            // When/Then
+            assertThatThrownBy(() -> categoryService.getCategoryById(categoryId))
+                    .isInstanceOf(CategoryNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("validateCategoryForType")
+    class ValidateCategoryForTypeTests {
+
+        @Test
+        @DisplayName("Should return category when type matches")
+        void validateCategoryForType_matches() {
+            // Given
+            UUID categoryId = salaryCategory.getId();
+            when(categoryRepository.findByIdAndActive(categoryId))
+                    .thenReturn(Optional.of(salaryCategory));
+
+            // When
+            Category result = categoryService.validateCategoryForType(categoryId, TransactionType.INCOME);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getType()).isEqualTo(TransactionType.INCOME);
+        }
+
+        @Test
+        @DisplayName("Should return category even when type does not match (logging only)")
+        void validateCategoryForType_mismatch() {
+            // Given - The method logs but doesn't throw on mismatch
+            UUID categoryId = salaryCategory.getId();
+            when(categoryRepository.findByIdAndActive(categoryId))
+                    .thenReturn(Optional.of(salaryCategory));
+
+            // When
+            Category result = categoryService.validateCategoryForType(categoryId, TransactionType.EXPENSE);
+
+            // Then - It returns the category but logs a debug message
+            assertThat(result).isNotNull();
+            assertThat(result.getType()).isEqualTo(TransactionType.INCOME);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when category does not exist")
+        void validateCategoryForType_notFound() {
+            // Given
+            UUID categoryId = UUID.randomUUID();
+            when(categoryRepository.findByIdAndActive(categoryId))
+                    .thenReturn(Optional.empty());
+
+            // When/Then
+            assertThatThrownBy(() -> categoryService.validateCategoryForType(categoryId, TransactionType.INCOME))
+                    .isInstanceOf(CategoryNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Category Response Mapping")
+    class CategoryResponseMappingTests {
+
+        @Test
+        @DisplayName("Should correctly map category entity to response")
+        void mapToResponse() {
+            // Given
+            when(categoryRepository.findAllIncomeCategories())
+                    .thenReturn(List.of(salaryCategory));
+            when(categoryRepository.findAllExpenseCategories())
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            CategoriesResponse result = categoryService.getAllCategories();
+
+            // Then
+            CategoryResponse response = result.income().get(0);
+            assertThat(response.id()).isEqualTo(salaryCategory.getId());
+            assertThat(response.name()).isEqualTo("Salary");
+            assertThat(response.type()).isEqualTo(TransactionType.INCOME);
+            assertThat(response.icon()).isEqualTo("payments");
+            assertThat(response.color()).isEqualTo("#4CAF50");
+        }
+
+        @Test
+        @DisplayName("Should preserve display order in response")
+        void preserveDisplayOrder() {
+            // Given - Categories returned in display order
+            Category thirdCategory = createCategory("Investments", TransactionType.INCOME, "trending_up", "#66BB6A", 3);
+            List<Category> orderedCategories = List.of(salaryCategory, freelanceCategory, thirdCategory);
+
+            when(categoryRepository.findAllIncomeCategories()).thenReturn(orderedCategories);
+            when(categoryRepository.findAllExpenseCategories()).thenReturn(Collections.emptyList());
+
+            // When
+            CategoriesResponse result = categoryService.getAllCategories();
+
+            // Then
+            assertThat(result.income()).hasSize(3);
+            assertThat(result.income().get(0).name()).isEqualTo("Salary");
+            assertThat(result.income().get(1).name()).isEqualTo("Freelance");
+            assertThat(result.income().get(2).name()).isEqualTo("Investments");
+        }
+    }
+}

--- a/backend/src/test/java/com/pfwa/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/pfwa/service/TransactionServiceTest.java
@@ -1,0 +1,652 @@
+package com.pfwa.service;
+
+import com.pfwa.dto.transaction.*;
+import com.pfwa.entity.Category;
+import com.pfwa.entity.Transaction;
+import com.pfwa.entity.TransactionType;
+import com.pfwa.entity.User;
+import com.pfwa.exception.CategoryTypeMismatchException;
+import com.pfwa.exception.TransactionNotFoundException;
+import com.pfwa.repository.CategoryRepository;
+import com.pfwa.repository.TransactionRepository;
+import com.pfwa.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TransactionService.
+ * Tests business logic with mocked repositories.
+ */
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @InjectMocks
+    private TransactionService transactionService;
+
+    @Captor
+    private ArgumentCaptor<Transaction> transactionCaptor;
+
+    private UUID testUserId;
+    private UUID testTransactionId;
+    private UUID testCategoryId;
+    private User testUser;
+    private Category testCategory;
+    private Transaction testTransaction;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = UUID.randomUUID();
+        testTransactionId = UUID.randomUUID();
+        testCategoryId = UUID.randomUUID();
+
+        testUser = new User("test@example.com", "hashedPassword");
+        setField(testUser, "id", testUserId);
+
+        testCategory = new Category("Food & Dining", TransactionType.EXPENSE, "restaurant", "#F44336", 1);
+        setField(testCategory, "id", testCategoryId);
+        testCategory.setActive(true);
+
+        testTransaction = new Transaction(
+                testUser,
+                testCategory,
+                new BigDecimal("150.00"),
+                TransactionType.EXPENSE,
+                LocalDate.of(2026, 1, 20)
+        );
+        setField(testTransaction, "id", testTransactionId);
+        testTransaction.setDescription("Grocery shopping");
+        testTransaction.setNotes("Weekly groceries");
+        setField(testTransaction, "createdAt", Instant.now());
+        setField(testTransaction, "updatedAt", Instant.now());
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field: " + fieldName, e);
+        }
+    }
+
+    @Nested
+    @DisplayName("createTransaction")
+    class CreateTransactionTests {
+
+        @Test
+        @DisplayName("Should create transaction with valid data")
+        void createTransaction_success() {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Grocery shopping",
+                    "Weekly groceries"
+            );
+
+            when(userRepository.getReferenceById(testUserId)).thenReturn(testUser);
+            when(categoryService.getCategoryById(testCategoryId)).thenReturn(testCategory);
+            when(transactionRepository.save(any(Transaction.class))).thenReturn(testTransaction);
+
+            // When
+            TransactionResponse result = transactionService.createTransaction(testUserId, request);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(testTransactionId);
+            assertThat(result.amount()).isEqualByComparingTo(new BigDecimal("150.00"));
+            assertThat(result.type()).isEqualTo(TransactionType.EXPENSE);
+            assertThat(result.category().name()).isEqualTo("Food & Dining");
+            assertThat(result.description()).isEqualTo("Grocery shopping");
+
+            verify(transactionRepository).save(transactionCaptor.capture());
+            Transaction saved = transactionCaptor.getValue();
+            assertThat(saved.getAmount()).isEqualByComparingTo(new BigDecimal("150.00"));
+            assertThat(saved.getType()).isEqualTo(TransactionType.EXPENSE);
+        }
+
+        @Test
+        @DisplayName("Should create transaction with null optional fields")
+        void createTransaction_nullOptionalFields() {
+            // Given
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("100.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    null,
+                    null
+            );
+
+            when(userRepository.getReferenceById(testUserId)).thenReturn(testUser);
+            when(categoryService.getCategoryById(testCategoryId)).thenReturn(testCategory);
+            when(transactionRepository.save(any(Transaction.class))).thenReturn(testTransaction);
+
+            // When
+            TransactionResponse result = transactionService.createTransaction(testUserId, request);
+
+            // Then
+            assertThat(result).isNotNull();
+            verify(transactionRepository).save(any(Transaction.class));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when category type does not match transaction type")
+        void createTransaction_categoryTypeMismatch() {
+            // Given
+            Category incomeCategory = new Category("Salary", TransactionType.INCOME, "payments", "#4CAF50", 1);
+            setField(incomeCategory, "id", testCategoryId);
+            incomeCategory.setActive(true);
+
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE, // Transaction is EXPENSE
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 20),
+                    "Test",
+                    null
+            );
+
+            when(categoryService.getCategoryById(testCategoryId)).thenReturn(incomeCategory);
+
+            // When/Then
+            assertThatThrownBy(() -> transactionService.createTransaction(testUserId, request))
+                    .isInstanceOf(CategoryTypeMismatchException.class);
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should create income transaction successfully")
+        void createTransaction_incomeType() {
+            // Given
+            UUID incomeCategoryId = UUID.randomUUID();
+            Category incomeCategory = new Category("Salary", TransactionType.INCOME, "payments", "#4CAF50", 1);
+            setField(incomeCategory, "id", incomeCategoryId);
+            incomeCategory.setActive(true);
+
+            Transaction incomeTransaction = new Transaction(
+                    testUser, incomeCategory, new BigDecimal("5000.00"),
+                    TransactionType.INCOME, LocalDate.of(2026, 1, 15)
+            );
+            setField(incomeTransaction, "id", UUID.randomUUID());
+            setField(incomeTransaction, "createdAt", Instant.now());
+            setField(incomeTransaction, "updatedAt", Instant.now());
+
+            CreateTransactionRequest request = new CreateTransactionRequest(
+                    new BigDecimal("5000.00"),
+                    TransactionType.INCOME,
+                    incomeCategoryId,
+                    LocalDate.of(2026, 1, 15),
+                    "Monthly salary",
+                    null
+            );
+
+            when(userRepository.getReferenceById(testUserId)).thenReturn(testUser);
+            when(categoryService.getCategoryById(incomeCategoryId)).thenReturn(incomeCategory);
+            when(transactionRepository.save(any(Transaction.class))).thenReturn(incomeTransaction);
+
+            // When
+            TransactionResponse result = transactionService.createTransaction(testUserId, request);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.type()).isEqualTo(TransactionType.INCOME);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTransaction")
+    class GetTransactionTests {
+
+        @Test
+        @DisplayName("Should return transaction when it exists and belongs to user")
+        void getTransaction_success() {
+            // Given
+            when(transactionRepository.findByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(Optional.of(testTransaction));
+
+            // When
+            TransactionResponse result = transactionService.getTransaction(testUserId, testTransactionId);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(testTransactionId);
+            assertThat(result.amount()).isEqualByComparingTo(new BigDecimal("150.00"));
+        }
+
+        @Test
+        @DisplayName("Should throw exception when transaction does not exist")
+        void getTransaction_notFound() {
+            // Given
+            when(transactionRepository.findByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(Optional.empty());
+
+            // When/Then
+            assertThatThrownBy(() -> transactionService.getTransaction(testUserId, testTransactionId))
+                    .isInstanceOf(TransactionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("Should not return transaction belonging to another user")
+        void getTransaction_wrongUser() {
+            // Given
+            UUID anotherUserId = UUID.randomUUID();
+            when(transactionRepository.findByIdAndUserId(testTransactionId, anotherUserId))
+                    .thenReturn(Optional.empty());
+
+            // When/Then
+            assertThatThrownBy(() -> transactionService.getTransaction(anotherUserId, testTransactionId))
+                    .isInstanceOf(TransactionNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTransactions")
+    class GetTransactionsTests {
+
+        @Test
+        @DisplayName("Should return paginated transactions for user")
+        void getTransactions_success() {
+            // Given
+            Pageable pageable = PageRequest.of(0, 20);
+            Page<Transaction> transactionPage = new PageImpl<>(
+                    List.of(testTransaction), pageable, 1
+            );
+
+            when(transactionRepository.findAll(any(Specification.class), eq(pageable)))
+                    .thenReturn(transactionPage);
+            when(transactionRepository.findAll(any(Specification.class)))
+                    .thenReturn(List.of(testTransaction));
+
+            // When
+            TransactionListResponse result = transactionService.getTransactions(
+                    testUserId, TransactionFilterRequest.empty(), pageable
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.totalElements()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("Should return empty list when no transactions exist")
+        void getTransactions_empty() {
+            // Given
+            Pageable pageable = PageRequest.of(0, 20);
+            Page<Transaction> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
+
+            when(transactionRepository.findAll(any(Specification.class), eq(pageable)))
+                    .thenReturn(emptyPage);
+            when(transactionRepository.findAll(any(Specification.class)))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            TransactionListResponse result = transactionService.getTransactions(
+                    testUserId, TransactionFilterRequest.empty(), pageable
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).isEmpty();
+            assertThat(result.totalElements()).isZero();
+        }
+
+        @Test
+        @DisplayName("Should calculate summary correctly")
+        void getTransactions_withSummary() {
+            // Given
+            Transaction incomeTransaction = new Transaction(
+                    testUser, testCategory, new BigDecimal("5000.00"),
+                    TransactionType.INCOME, LocalDate.of(2026, 1, 15)
+            );
+            setField(incomeTransaction, "id", UUID.randomUUID());
+            setField(incomeTransaction, "createdAt", Instant.now());
+            setField(incomeTransaction, "updatedAt", Instant.now());
+
+            Transaction expenseTransaction = new Transaction(
+                    testUser, testCategory, new BigDecimal("1500.00"),
+                    TransactionType.EXPENSE, LocalDate.of(2026, 1, 20)
+            );
+            setField(expenseTransaction, "id", UUID.randomUUID());
+            setField(expenseTransaction, "createdAt", Instant.now());
+            setField(expenseTransaction, "updatedAt", Instant.now());
+
+            Pageable pageable = PageRequest.of(0, 20);
+            Page<Transaction> transactionPage = new PageImpl<>(
+                    List.of(incomeTransaction, expenseTransaction), pageable, 2
+            );
+
+            when(transactionRepository.findAll(any(Specification.class), eq(pageable)))
+                    .thenReturn(transactionPage);
+            when(transactionRepository.findAll(any(Specification.class)))
+                    .thenReturn(List.of(incomeTransaction))
+                    .thenReturn(List.of(expenseTransaction));
+
+            // When
+            TransactionListResponse result = transactionService.getTransactions(
+                    testUserId, TransactionFilterRequest.empty(), pageable
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTransaction")
+    class UpdateTransactionTests {
+
+        @Test
+        @DisplayName("Should update transaction successfully")
+        void updateTransaction_success() {
+            // Given
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("175.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 21),
+                    "Updated description",
+                    "Updated notes"
+            );
+
+            when(transactionRepository.findByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(Optional.of(testTransaction));
+            when(categoryService.getCategoryById(testCategoryId)).thenReturn(testCategory);
+            when(transactionRepository.save(any(Transaction.class))).thenReturn(testTransaction);
+
+            // When
+            TransactionResponse result = transactionService.updateTransaction(
+                    testUserId, testTransactionId, request
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            verify(transactionRepository).save(transactionCaptor.capture());
+            Transaction saved = transactionCaptor.getValue();
+            assertThat(saved.getAmount()).isEqualByComparingTo(new BigDecimal("175.00"));
+            assertThat(saved.getDescription()).isEqualTo("Updated description");
+        }
+
+        @Test
+        @DisplayName("Should throw exception when updating non-existent transaction")
+        void updateTransaction_notFound() {
+            // Given
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("175.00"),
+                    TransactionType.EXPENSE,
+                    testCategoryId,
+                    LocalDate.of(2026, 1, 21),
+                    "Updated",
+                    null
+            );
+
+            when(transactionRepository.findByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(Optional.empty());
+
+            // When/Then
+            assertThatThrownBy(() -> transactionService.updateTransaction(testUserId, testTransactionId, request))
+                    .isInstanceOf(TransactionNotFoundException.class);
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw exception when changing to incompatible category")
+        void updateTransaction_categoryTypeMismatch() {
+            // Given
+            Category incomeCategory = new Category("Salary", TransactionType.INCOME, "payments", "#4CAF50", 1);
+            UUID incomeCategoryId = UUID.randomUUID();
+            setField(incomeCategory, "id", incomeCategoryId);
+            incomeCategory.setActive(true);
+
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("175.00"),
+                    TransactionType.EXPENSE, // Keeping as EXPENSE
+                    incomeCategoryId, // But using INCOME category
+                    LocalDate.of(2026, 1, 21),
+                    "Updated",
+                    null
+            );
+
+            when(transactionRepository.findByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(Optional.of(testTransaction));
+            when(categoryService.getCategoryById(incomeCategoryId)).thenReturn(incomeCategory);
+
+            // When/Then
+            assertThatThrownBy(() -> transactionService.updateTransaction(testUserId, testTransactionId, request))
+                    .isInstanceOf(CategoryTypeMismatchException.class);
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should allow changing transaction type with compatible category")
+        void updateTransaction_changeType() {
+            // Given
+            UUID incomeCategoryId = UUID.randomUUID();
+            Category incomeCategory = new Category("Refunds", TransactionType.INCOME, "receipt", "#9CCC65", 1);
+            setField(incomeCategory, "id", incomeCategoryId);
+            incomeCategory.setActive(true);
+
+            UpdateTransactionRequest request = new UpdateTransactionRequest(
+                    new BigDecimal("50.00"),
+                    TransactionType.INCOME, // Changing type
+                    incomeCategoryId,
+                    LocalDate.of(2026, 1, 21),
+                    "Refund from store",
+                    null
+            );
+
+            when(transactionRepository.findByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(Optional.of(testTransaction));
+            when(categoryService.getCategoryById(incomeCategoryId)).thenReturn(incomeCategory);
+            when(transactionRepository.save(any(Transaction.class))).thenReturn(testTransaction);
+
+            // When
+            transactionService.updateTransaction(testUserId, testTransactionId, request);
+
+            // Then
+            verify(transactionRepository).save(transactionCaptor.capture());
+            Transaction saved = transactionCaptor.getValue();
+            assertThat(saved.getType()).isEqualTo(TransactionType.INCOME);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteTransaction")
+    class DeleteTransactionTests {
+
+        @Test
+        @DisplayName("Should delete transaction successfully")
+        void deleteTransaction_success() {
+            // Given
+            when(transactionRepository.deleteByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(1);
+
+            // When
+            transactionService.deleteTransaction(testUserId, testTransactionId);
+
+            // Then
+            verify(transactionRepository).deleteByIdAndUserId(testTransactionId, testUserId);
+        }
+
+        @Test
+        @DisplayName("Should throw exception when deleting non-existent transaction")
+        void deleteTransaction_notFound() {
+            // Given
+            when(transactionRepository.deleteByIdAndUserId(testTransactionId, testUserId))
+                    .thenReturn(0);
+
+            // When/Then
+            assertThatThrownBy(() -> transactionService.deleteTransaction(testUserId, testTransactionId))
+                    .isInstanceOf(TransactionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("Should not delete transaction belonging to another user")
+        void deleteTransaction_wrongUser() {
+            // Given
+            UUID anotherUserId = UUID.randomUUID();
+            when(transactionRepository.deleteByIdAndUserId(testTransactionId, anotherUserId))
+                    .thenReturn(0);
+
+            // When/Then
+            assertThatThrownBy(() -> transactionService.deleteTransaction(anotherUserId, testTransactionId))
+                    .isInstanceOf(TransactionNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTransactionSummary")
+    class GetTransactionSummaryTests {
+
+        @Test
+        @DisplayName("Should return transaction summary for date range")
+        void getSummary_withDateRange() {
+            // Given
+            LocalDate startDate = LocalDate.of(2026, 1, 1);
+            LocalDate endDate = LocalDate.of(2026, 1, 31);
+
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    testUserId, TransactionType.INCOME, startDate, endDate))
+                    .thenReturn(new BigDecimal("5000.00"));
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    testUserId, TransactionType.EXPENSE, startDate, endDate))
+                    .thenReturn(new BigDecimal("3250.50"));
+            when(transactionRepository.countByUserIdAndTypeAndDateRange(
+                    testUserId, TransactionType.INCOME, startDate, endDate))
+                    .thenReturn(2L);
+            when(transactionRepository.countByUserIdAndTypeAndDateRange(
+                    testUserId, TransactionType.EXPENSE, startDate, endDate))
+                    .thenReturn(45L);
+            when(transactionRepository.findAll(any(Specification.class)))
+                    .thenReturn(Collections.emptyList());
+
+            // Previous period
+            LocalDate prevStartDate = startDate.minusDays(31);
+            LocalDate prevEndDate = startDate.minusDays(1);
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    testUserId, TransactionType.INCOME, prevStartDate, prevEndDate))
+                    .thenReturn(new BigDecimal("4500.00"));
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    testUserId, TransactionType.EXPENSE, prevStartDate, prevEndDate))
+                    .thenReturn(new BigDecimal("2800.00"));
+
+            // When
+            TransactionSummaryResponse result = transactionService.getTransactionSummary(
+                    testUserId, startDate, endDate
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.totals().income()).isEqualByComparingTo(new BigDecimal("5000.00"));
+            assertThat(result.totals().expenses()).isEqualByComparingTo(new BigDecimal("3250.50"));
+            assertThat(result.totals().net()).isEqualByComparingTo(new BigDecimal("1749.50"));
+            assertThat(result.totals().transactionCount()).isEqualTo(47);
+        }
+
+        @Test
+        @DisplayName("Should use current month when no dates provided")
+        void getSummary_defaultsToCurrentMonth() {
+            // Given
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    eq(testUserId), eq(TransactionType.INCOME), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(BigDecimal.ZERO);
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    eq(testUserId), eq(TransactionType.EXPENSE), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(BigDecimal.ZERO);
+            when(transactionRepository.countByUserIdAndTypeAndDateRange(
+                    eq(testUserId), any(TransactionType.class), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(0L);
+            when(transactionRepository.findAll(any(Specification.class)))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            TransactionSummaryResponse result = transactionService.getTransactionSummary(
+                    testUserId, null, null
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.period().startDate()).isEqualTo(LocalDate.now().withDayOfMonth(1));
+            assertThat(result.period().endDate()).isEqualTo(LocalDate.now());
+        }
+
+        @Test
+        @DisplayName("Should return zero totals when no transactions exist")
+        void getSummary_noTransactions() {
+            // Given
+            LocalDate startDate = LocalDate.of(2026, 1, 1);
+            LocalDate endDate = LocalDate.of(2026, 1, 31);
+
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    eq(testUserId), any(TransactionType.class), eq(startDate), eq(endDate)))
+                    .thenReturn(BigDecimal.ZERO);
+            when(transactionRepository.countByUserIdAndTypeAndDateRange(
+                    eq(testUserId), any(TransactionType.class), eq(startDate), eq(endDate)))
+                    .thenReturn(0L);
+            when(transactionRepository.findAll(any(Specification.class)))
+                    .thenReturn(Collections.emptyList());
+
+            // Previous period
+            when(transactionRepository.sumAmountByUserIdAndTypeAndDateRange(
+                    eq(testUserId), any(TransactionType.class), any(LocalDate.class), any(LocalDate.class)))
+                    .thenReturn(BigDecimal.ZERO);
+
+            // When
+            TransactionSummaryResponse result = transactionService.getTransactionSummary(
+                    testUserId, startDate, endDate
+            );
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.totals().income()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(result.totals().expenses()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(result.totals().net()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(result.totals().transactionCount()).isZero();
+        }
+    }
+}

--- a/docs/api/transaction-endpoints.yaml
+++ b/docs/api/transaction-endpoints.yaml
@@ -1,0 +1,1453 @@
+openapi: 3.0.3
+info:
+  title: PFWA Transactions API
+  description: |
+    Transactions API for the Personal Finance Web Application (PFWA).
+
+    This API provides endpoints for managing financial transactions including
+    income and expenses, categories, filtering, search, pagination, and summary statistics.
+
+    ## Authentication
+    All endpoints require JWT Bearer authentication. Tokens are stored in HttpOnly cookies
+    and automatically sent with requests. The `Authorization` header is also supported.
+
+    ## Rate Limiting
+    All endpoints are rate-limited. When exceeded, a 429 response is returned with
+    a `Retry-After` header indicating when the client can retry.
+
+    ## Error Handling
+    All error responses follow a consistent format with error codes and field-level
+    validation errors where applicable.
+
+    ## Pagination
+    List endpoints support pagination via `page` and `size` query parameters.
+    Default page size is 20, maximum is 100.
+
+    ## Sorting
+    List endpoints support sorting via the `sort` query parameter.
+    Format: `field,direction` (e.g., `date,desc`).
+  version: 1.0.0
+  contact:
+    name: PFWA Development Team
+    email: dev@pfwa.com
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+servers:
+  - url: http://localhost:8080/api/v1
+    description: Local development server
+  - url: https://api.pfwa.com/api/v1
+    description: Production server
+
+tags:
+  - name: Transactions
+    description: Transaction CRUD operations
+  - name: Categories
+    description: Transaction category management
+  - name: Summary
+    description: Transaction statistics and summaries
+
+paths:
+  /transactions:
+    get:
+      tags:
+        - Transactions
+      summary: List transactions with filtering and pagination
+      description: |
+        Retrieves a paginated list of transactions for the authenticated user.
+        Supports filtering by date range, type, categories, amount range, and text search.
+        Results are sorted by date descending by default.
+
+        **Rate Limit:** 60 requests per minute per user.
+      operationId: listTransactions
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/X-Request-ID'
+        - $ref: '#/components/parameters/PageParam'
+        - $ref: '#/components/parameters/SizeParam'
+        - $ref: '#/components/parameters/SortParam'
+        - name: startDate
+          in: query
+          description: Filter transactions on or after this date (inclusive)
+          schema:
+            type: string
+            format: date
+          example: "2026-01-01"
+        - name: endDate
+          in: query
+          description: Filter transactions on or before this date (inclusive)
+          schema:
+            type: string
+            format: date
+          example: "2026-01-31"
+        - name: type
+          in: query
+          description: Filter by transaction type
+          schema:
+            $ref: '#/components/schemas/TransactionType'
+        - name: categoryIds
+          in: query
+          description: Filter by category IDs (comma-separated for multiple)
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+          style: form
+          explode: false
+          example: "550e8400-e29b-41d4-a716-446655440001,550e8400-e29b-41d4-a716-446655440002"
+        - name: minAmount
+          in: query
+          description: Filter transactions with amount greater than or equal to this value
+          schema:
+            type: number
+            format: decimal
+            minimum: 0
+          example: 50.00
+        - name: maxAmount
+          in: query
+          description: Filter transactions with amount less than or equal to this value
+          schema:
+            type: number
+            format: decimal
+            minimum: 0
+          example: 500.00
+        - name: search
+          in: query
+          description: |
+            Search transactions by description or notes (case-insensitive, partial match).
+            Minimum 2 characters required.
+          schema:
+            type: string
+            minLength: 2
+            maxLength: 100
+          example: "grocery"
+      responses:
+        '200':
+          description: Transactions retrieved successfully
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionListResponse'
+              example:
+                content:
+                  - id: "550e8400-e29b-41d4-a716-446655440000"
+                    amount: 150.00
+                    type: "EXPENSE"
+                    category:
+                      id: "550e8400-e29b-41d4-a716-446655440010"
+                      name: "Food & Dining"
+                      type: "EXPENSE"
+                      icon: "restaurant"
+                      color: "#F44336"
+                    date: "2026-01-20"
+                    description: "Grocery shopping at Whole Foods"
+                    notes: "Weekly groceries"
+                    createdAt: "2026-01-20T14:30:00Z"
+                    updatedAt: "2026-01-20T14:30:00Z"
+                page: 0
+                size: 20
+                totalElements: 125
+                totalPages: 7
+                first: true
+                last: false
+                summary:
+                  totalIncome: 5000.00
+                  totalExpenses: 3250.50
+                  netBalance: 1749.50
+                appliedFilters:
+                  startDate: null
+                  endDate: null
+                  type: null
+                  categoryIds: []
+                  minAmount: null
+                  maxAmount: null
+                  search: null
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    post:
+      tags:
+        - Transactions
+      summary: Create a new transaction
+      description: |
+        Creates a new income or expense transaction for the authenticated user.
+        The transaction is associated with a category matching the transaction type.
+
+        **Rate Limit:** 30 requests per minute per user.
+      operationId: createTransaction
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/X-Request-ID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTransactionRequest'
+            examples:
+              expenseTransaction:
+                summary: Create expense transaction
+                value:
+                  amount: 150.00
+                  type: "EXPENSE"
+                  categoryId: "550e8400-e29b-41d4-a716-446655440010"
+                  date: "2026-01-20"
+                  description: "Grocery shopping at Whole Foods"
+                  notes: "Weekly groceries"
+              incomeTransaction:
+                summary: Create income transaction
+                value:
+                  amount: 5000.00
+                  type: "INCOME"
+                  categoryId: "550e8400-e29b-41d4-a716-446655440001"
+                  date: "2026-01-15"
+                  description: "Monthly salary"
+                  notes: "January 2026 paycheck"
+      responses:
+        '201':
+          description: Transaction created successfully
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+            Location:
+              description: URL of the created transaction
+              schema:
+                type: string
+              example: "/api/v1/transactions/550e8400-e29b-41d4-a716-446655440000"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionResponse'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440000"
+                amount: 150.00
+                type: "EXPENSE"
+                category:
+                  id: "550e8400-e29b-41d4-a716-446655440010"
+                  name: "Food & Dining"
+                  type: "EXPENSE"
+                  icon: "restaurant"
+                  color: "#F44336"
+                date: "2026-01-20"
+                description: "Grocery shopping at Whole Foods"
+                notes: "Weekly groceries"
+                createdAt: "2026-01-20T14:30:00Z"
+                updatedAt: "2026-01-20T14:30:00Z"
+        '400':
+          description: Validation error
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                amountInvalid:
+                  summary: Invalid amount
+                  value:
+                    error: "VALIDATION_ERROR"
+                    message: "Validation failed"
+                    timestamp: "2026-01-23T10:30:00Z"
+                    path: "/api/v1/transactions"
+                    fieldErrors:
+                      - field: "amount"
+                        message: "Amount must be greater than 0"
+                        code: "amount.positive"
+                categoryTypeMismatch:
+                  summary: Category type mismatch
+                  value:
+                    error: "VALIDATION_ERROR"
+                    message: "Validation failed"
+                    timestamp: "2026-01-23T10:30:00Z"
+                    path: "/api/v1/transactions"
+                    fieldErrors:
+                      - field: "categoryId"
+                        message: "Category type must match transaction type"
+                        code: "category.type.mismatch"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Category not found
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: "NOT_FOUND"
+                message: "Category not found"
+                timestamp: "2026-01-23T10:30:00Z"
+                path: "/api/v1/transactions"
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /transactions/{id}:
+    get:
+      tags:
+        - Transactions
+      summary: Get transaction by ID
+      description: |
+        Retrieves a specific transaction by its unique identifier.
+        Users can only access their own transactions.
+      operationId: getTransaction
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/X-Request-ID'
+        - $ref: '#/components/parameters/TransactionIdParam'
+      responses:
+        '200':
+          description: Transaction retrieved successfully
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    put:
+      tags:
+        - Transactions
+      summary: Update transaction
+      description: |
+        Updates an existing transaction. All fields except `id`, `createdAt`, and `userId`
+        can be modified. Users can only update their own transactions.
+
+        When changing the transaction type, the category must also be changed to one
+        matching the new type.
+
+        **Rate Limit:** 30 requests per minute per user.
+      operationId: updateTransaction
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/X-Request-ID'
+        - $ref: '#/components/parameters/TransactionIdParam'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTransactionRequest'
+            example:
+              amount: 175.00
+              type: "EXPENSE"
+              categoryId: "550e8400-e29b-41d4-a716-446655440010"
+              date: "2026-01-20"
+              description: "Updated grocery shopping"
+              notes: "Added extra items"
+      responses:
+        '200':
+          description: Transaction updated successfully
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionResponse'
+              example:
+                id: "550e8400-e29b-41d4-a716-446655440000"
+                amount: 175.00
+                type: "EXPENSE"
+                category:
+                  id: "550e8400-e29b-41d4-a716-446655440010"
+                  name: "Food & Dining"
+                  type: "EXPENSE"
+                  icon: "restaurant"
+                  color: "#F44336"
+                date: "2026-01-20"
+                description: "Updated grocery shopping"
+                notes: "Added extra items"
+                createdAt: "2026-01-20T14:30:00Z"
+                updatedAt: "2026-01-20T15:45:00Z"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    delete:
+      tags:
+        - Transactions
+      summary: Delete transaction
+      description: |
+        Permanently deletes a transaction. Users can only delete their own transactions.
+        This action cannot be undone.
+
+        If the transaction is linked to a budget, the budget progress will be recalculated.
+
+        **Rate Limit:** 30 requests per minute per user.
+      operationId: deleteTransaction
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/X-Request-ID'
+        - $ref: '#/components/parameters/TransactionIdParam'
+      responses:
+        '204':
+          description: Transaction deleted successfully
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /transactions/summary:
+    get:
+      tags:
+        - Summary
+      summary: Get transaction summary and statistics
+      description: |
+        Retrieves summary statistics for the authenticated user's transactions
+        including totals by type, category breakdown, and comparison with previous period.
+
+        Supports the same date range filters as the transaction list endpoint.
+
+        **Rate Limit:** 30 requests per minute per user.
+      operationId: getTransactionSummary
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/X-Request-ID'
+        - name: startDate
+          in: query
+          description: Start date for summary period (inclusive)
+          schema:
+            type: string
+            format: date
+          example: "2026-01-01"
+        - name: endDate
+          in: query
+          description: End date for summary period (inclusive)
+          schema:
+            type: string
+            format: date
+          example: "2026-01-31"
+      responses:
+        '200':
+          description: Summary retrieved successfully
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionSummaryResponse'
+              example:
+                period:
+                  startDate: "2026-01-01"
+                  endDate: "2026-01-31"
+                totals:
+                  income: 5000.00
+                  expenses: 3250.50
+                  net: 1749.50
+                  transactionCount: 87
+                categoryBreakdown:
+                  income:
+                    - category:
+                        id: "550e8400-e29b-41d4-a716-446655440001"
+                        name: "Salary"
+                        icon: "payments"
+                        color: "#4CAF50"
+                      total: 4500.00
+                      percentage: 90.0
+                      transactionCount: 2
+                    - category:
+                        id: "550e8400-e29b-41d4-a716-446655440002"
+                        name: "Freelance"
+                        icon: "work"
+                        color: "#8BC34A"
+                      total: 500.00
+                      percentage: 10.0
+                      transactionCount: 1
+                  expense:
+                    - category:
+                        id: "550e8400-e29b-41d4-a716-446655440010"
+                        name: "Food & Dining"
+                        icon: "restaurant"
+                        color: "#F44336"
+                      total: 850.00
+                      percentage: 26.15
+                      transactionCount: 18
+                    - category:
+                        id: "550e8400-e29b-41d4-a716-446655440011"
+                        name: "Transportation"
+                        icon: "directions_car"
+                        color: "#E91E63"
+                      total: 400.00
+                      percentage: 12.31
+                      transactionCount: 8
+                comparison:
+                  previousPeriod:
+                    startDate: "2025-12-01"
+                    endDate: "2025-12-31"
+                    income: 4500.00
+                    expenses: 2800.00
+                    net: 1700.00
+                  change:
+                    income: "+11.1%"
+                    expenses: "+16.1%"
+                    net: "+2.9%"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /categories:
+    get:
+      tags:
+        - Categories
+      summary: Get all transaction categories
+      description: |
+        Retrieves all available transaction categories grouped by type (INCOME/EXPENSE).
+        Categories are system-defined and cannot be modified by users in the MVP.
+
+        This endpoint should be cached by clients as categories rarely change.
+
+        **Rate Limit:** 60 requests per minute per user.
+      operationId: getCategories
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/X-Request-ID'
+        - name: type
+          in: query
+          description: Filter categories by type
+          schema:
+            $ref: '#/components/schemas/TransactionType'
+      responses:
+        '200':
+          description: Categories retrieved successfully
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+            Cache-Control:
+              description: Caching directive
+              schema:
+                type: string
+              example: "max-age=3600"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CategoriesResponse'
+              example:
+                income:
+                  - id: "550e8400-e29b-41d4-a716-446655440001"
+                    name: "Salary"
+                    type: "INCOME"
+                    icon: "payments"
+                    color: "#4CAF50"
+                  - id: "550e8400-e29b-41d4-a716-446655440002"
+                    name: "Freelance"
+                    type: "INCOME"
+                    icon: "work"
+                    color: "#8BC34A"
+                  - id: "550e8400-e29b-41d4-a716-446655440003"
+                    name: "Investments"
+                    type: "INCOME"
+                    icon: "trending_up"
+                    color: "#66BB6A"
+                  - id: "550e8400-e29b-41d4-a716-446655440004"
+                    name: "Gifts"
+                    type: "INCOME"
+                    icon: "card_giftcard"
+                    color: "#81C784"
+                  - id: "550e8400-e29b-41d4-a716-446655440005"
+                    name: "Refunds"
+                    type: "INCOME"
+                    icon: "receipt"
+                    color: "#9CCC65"
+                  - id: "550e8400-e29b-41d4-a716-446655440006"
+                    name: "Other Income"
+                    type: "INCOME"
+                    icon: "attach_money"
+                    color: "#AED581"
+                expense:
+                  - id: "550e8400-e29b-41d4-a716-446655440010"
+                    name: "Food & Dining"
+                    type: "EXPENSE"
+                    icon: "restaurant"
+                    color: "#F44336"
+                  - id: "550e8400-e29b-41d4-a716-446655440011"
+                    name: "Transportation"
+                    type: "EXPENSE"
+                    icon: "directions_car"
+                    color: "#E91E63"
+                  - id: "550e8400-e29b-41d4-a716-446655440012"
+                    name: "Housing"
+                    type: "EXPENSE"
+                    icon: "home"
+                    color: "#9C27B0"
+                  - id: "550e8400-e29b-41d4-a716-446655440013"
+                    name: "Utilities"
+                    type: "EXPENSE"
+                    icon: "bolt"
+                    color: "#673AB7"
+                  - id: "550e8400-e29b-41d4-a716-446655440014"
+                    name: "Entertainment"
+                    type: "EXPENSE"
+                    icon: "movie"
+                    color: "#3F51B5"
+                  - id: "550e8400-e29b-41d4-a716-446655440015"
+                    name: "Healthcare"
+                    type: "EXPENSE"
+                    icon: "local_hospital"
+                    color: "#2196F3"
+                  - id: "550e8400-e29b-41d4-a716-446655440016"
+                    name: "Shopping"
+                    type: "EXPENSE"
+                    icon: "shopping_bag"
+                    color: "#03A9F4"
+                  - id: "550e8400-e29b-41d4-a716-446655440017"
+                    name: "Education"
+                    type: "EXPENSE"
+                    icon: "school"
+                    color: "#00BCD4"
+                  - id: "550e8400-e29b-41d4-a716-446655440018"
+                    name: "Travel"
+                    type: "EXPENSE"
+                    icon: "flight"
+                    color: "#009688"
+                  - id: "550e8400-e29b-41d4-a716-446655440019"
+                    name: "Personal Care"
+                    type: "EXPENSE"
+                    icon: "spa"
+                    color: "#4CAF50"
+                  - id: "550e8400-e29b-41d4-a716-446655440020"
+                    name: "Subscriptions"
+                    type: "EXPENSE"
+                    icon: "subscriptions"
+                    color: "#8BC34A"
+                  - id: "550e8400-e29b-41d4-a716-446655440021"
+                    name: "Other"
+                    type: "EXPENSE"
+                    icon: "more_horiz"
+                    color: "#CDDC39"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT access token in Authorization header
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: accessToken
+      description: JWT access token in HttpOnly cookie
+
+  parameters:
+    X-Request-ID:
+      name: X-Request-ID
+      in: header
+      required: false
+      description: Unique identifier for request tracing. Generated by client or server.
+      schema:
+        type: string
+        format: uuid
+      example: "550e8400-e29b-41d4-a716-446655440000"
+
+    TransactionIdParam:
+      name: id
+      in: path
+      required: true
+      description: Unique identifier of the transaction
+      schema:
+        type: string
+        format: uuid
+      example: "550e8400-e29b-41d4-a716-446655440000"
+
+    PageParam:
+      name: page
+      in: query
+      description: Zero-based page index
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      example: 0
+
+    SizeParam:
+      name: size
+      in: query
+      description: Number of items per page (max 100)
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+      example: 20
+
+    SortParam:
+      name: sort
+      in: query
+      description: |
+        Sort field and direction. Format: `field,direction`.
+        Supported fields: date, amount, category, createdAt.
+        Supported directions: asc, desc.
+      schema:
+        type: string
+        default: "date,desc"
+      example: "date,desc"
+
+  headers:
+    X-Request-ID:
+      description: Request identifier for tracing
+      schema:
+        type: string
+        format: uuid
+      example: "550e8400-e29b-41d4-a716-446655440000"
+
+  schemas:
+    # ==================== Enums ====================
+
+    TransactionType:
+      type: string
+      enum:
+        - INCOME
+        - EXPENSE
+      description: Type of transaction
+
+    # ==================== Request DTOs ====================
+
+    CreateTransactionRequest:
+      type: object
+      required:
+        - amount
+        - type
+        - categoryId
+        - date
+      properties:
+        amount:
+          type: number
+          format: decimal
+          minimum: 0.01
+          maximum: 10000000
+          description: Transaction amount (must be greater than 0)
+          example: 150.00
+        type:
+          $ref: '#/components/schemas/TransactionType'
+        categoryId:
+          type: string
+          format: uuid
+          description: ID of the category (must match transaction type)
+          example: "550e8400-e29b-41d4-a716-446655440010"
+        date:
+          type: string
+          format: date
+          description: Transaction date (cannot be more than 1 year in the past)
+          example: "2026-01-20"
+        description:
+          type: string
+          maxLength: 500
+          nullable: true
+          description: Brief description of the transaction
+          example: "Grocery shopping at Whole Foods"
+        notes:
+          type: string
+          maxLength: 1000
+          nullable: true
+          description: Additional notes about the transaction
+          example: "Weekly groceries"
+
+    UpdateTransactionRequest:
+      type: object
+      required:
+        - amount
+        - type
+        - categoryId
+        - date
+      properties:
+        amount:
+          type: number
+          format: decimal
+          minimum: 0.01
+          maximum: 10000000
+          description: Transaction amount (must be greater than 0)
+          example: 175.00
+        type:
+          $ref: '#/components/schemas/TransactionType'
+        categoryId:
+          type: string
+          format: uuid
+          description: ID of the category (must match transaction type)
+          example: "550e8400-e29b-41d4-a716-446655440010"
+        date:
+          type: string
+          format: date
+          description: Transaction date
+          example: "2026-01-20"
+        description:
+          type: string
+          maxLength: 500
+          nullable: true
+          description: Brief description of the transaction
+          example: "Updated grocery shopping"
+        notes:
+          type: string
+          maxLength: 1000
+          nullable: true
+          description: Additional notes about the transaction
+          example: "Added extra items"
+
+    # ==================== Response DTOs ====================
+
+    TransactionResponse:
+      type: object
+      required:
+        - id
+        - amount
+        - type
+        - category
+        - date
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier of the transaction
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        amount:
+          type: number
+          format: decimal
+          description: Transaction amount
+          example: 150.00
+        type:
+          $ref: '#/components/schemas/TransactionType'
+        category:
+          $ref: '#/components/schemas/CategoryResponse'
+        date:
+          type: string
+          format: date
+          description: Transaction date
+          example: "2026-01-20"
+        description:
+          type: string
+          nullable: true
+          description: Brief description of the transaction
+          example: "Grocery shopping at Whole Foods"
+        notes:
+          type: string
+          nullable: true
+          description: Additional notes about the transaction
+          example: "Weekly groceries"
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when the transaction was created
+          example: "2026-01-20T14:30:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the transaction was last updated
+          example: "2026-01-20T14:30:00Z"
+
+    TransactionListResponse:
+      type: object
+      required:
+        - content
+        - page
+        - size
+        - totalElements
+        - totalPages
+        - first
+        - last
+        - summary
+      properties:
+        content:
+          type: array
+          description: List of transactions
+          items:
+            $ref: '#/components/schemas/TransactionResponse'
+        page:
+          type: integer
+          description: Current page number (zero-based)
+          example: 0
+        size:
+          type: integer
+          description: Number of items per page
+          example: 20
+        totalElements:
+          type: integer
+          format: int64
+          description: Total number of transactions matching the query
+          example: 125
+        totalPages:
+          type: integer
+          description: Total number of pages
+          example: 7
+        first:
+          type: boolean
+          description: Whether this is the first page
+          example: true
+        last:
+          type: boolean
+          description: Whether this is the last page
+          example: false
+        summary:
+          $ref: '#/components/schemas/TransactionListSummary'
+        appliedFilters:
+          $ref: '#/components/schemas/AppliedFilters'
+
+    TransactionListSummary:
+      type: object
+      required:
+        - totalIncome
+        - totalExpenses
+        - netBalance
+      properties:
+        totalIncome:
+          type: number
+          format: decimal
+          description: Sum of all income transactions (filtered)
+          example: 5000.00
+        totalExpenses:
+          type: number
+          format: decimal
+          description: Sum of all expense transactions (filtered)
+          example: 3250.50
+        netBalance:
+          type: number
+          format: decimal
+          description: Net balance (income - expenses)
+          example: 1749.50
+
+    AppliedFilters:
+      type: object
+      description: Echo of the filters applied to the request
+      properties:
+        startDate:
+          type: string
+          format: date
+          nullable: true
+          example: "2026-01-01"
+        endDate:
+          type: string
+          format: date
+          nullable: true
+          example: "2026-01-31"
+        type:
+          $ref: '#/components/schemas/TransactionType'
+        categoryIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          example: []
+        minAmount:
+          type: number
+          format: decimal
+          nullable: true
+          example: 50.00
+        maxAmount:
+          type: number
+          format: decimal
+          nullable: true
+          example: 500.00
+        search:
+          type: string
+          nullable: true
+          example: "grocery"
+
+    CategoryResponse:
+      type: object
+      required:
+        - id
+        - name
+        - type
+        - icon
+        - color
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier of the category
+          example: "550e8400-e29b-41d4-a716-446655440010"
+        name:
+          type: string
+          description: Display name of the category
+          example: "Food & Dining"
+        type:
+          $ref: '#/components/schemas/TransactionType'
+        icon:
+          type: string
+          description: Material icon name for the category
+          example: "restaurant"
+        color:
+          type: string
+          pattern: '^#[0-9A-Fa-f]{6}$'
+          description: Hex color code for the category
+          example: "#F44336"
+
+    CategoriesResponse:
+      type: object
+      required:
+        - income
+        - expense
+      properties:
+        income:
+          type: array
+          description: List of income categories
+          items:
+            $ref: '#/components/schemas/CategoryResponse'
+        expense:
+          type: array
+          description: List of expense categories
+          items:
+            $ref: '#/components/schemas/CategoryResponse'
+
+    TransactionSummaryResponse:
+      type: object
+      required:
+        - period
+        - totals
+        - categoryBreakdown
+      properties:
+        period:
+          $ref: '#/components/schemas/SummaryPeriod'
+        totals:
+          $ref: '#/components/schemas/SummaryTotals'
+        categoryBreakdown:
+          $ref: '#/components/schemas/CategoryBreakdown'
+        comparison:
+          $ref: '#/components/schemas/PeriodComparison'
+
+    SummaryPeriod:
+      type: object
+      required:
+        - startDate
+        - endDate
+      properties:
+        startDate:
+          type: string
+          format: date
+          description: Start of the summary period
+          example: "2026-01-01"
+        endDate:
+          type: string
+          format: date
+          description: End of the summary period
+          example: "2026-01-31"
+
+    SummaryTotals:
+      type: object
+      required:
+        - income
+        - expenses
+        - net
+        - transactionCount
+      properties:
+        income:
+          type: number
+          format: decimal
+          description: Total income for the period
+          example: 5000.00
+        expenses:
+          type: number
+          format: decimal
+          description: Total expenses for the period
+          example: 3250.50
+        net:
+          type: number
+          format: decimal
+          description: Net balance (income - expenses)
+          example: 1749.50
+        transactionCount:
+          type: integer
+          description: Total number of transactions in the period
+          example: 87
+
+    CategoryBreakdown:
+      type: object
+      required:
+        - income
+        - expense
+      properties:
+        income:
+          type: array
+          description: Breakdown of income by category
+          items:
+            $ref: '#/components/schemas/CategoryBreakdownItem'
+        expense:
+          type: array
+          description: Breakdown of expenses by category
+          items:
+            $ref: '#/components/schemas/CategoryBreakdownItem'
+
+    CategoryBreakdownItem:
+      type: object
+      required:
+        - category
+        - total
+        - percentage
+        - transactionCount
+      properties:
+        category:
+          $ref: '#/components/schemas/CategorySummary'
+        total:
+          type: number
+          format: decimal
+          description: Total amount for this category
+          example: 850.00
+        percentage:
+          type: number
+          format: decimal
+          minimum: 0
+          maximum: 100
+          description: Percentage of total for this type
+          example: 26.15
+        transactionCount:
+          type: integer
+          description: Number of transactions in this category
+          example: 18
+
+    CategorySummary:
+      type: object
+      required:
+        - id
+        - name
+        - icon
+        - color
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: "550e8400-e29b-41d4-a716-446655440010"
+        name:
+          type: string
+          example: "Food & Dining"
+        icon:
+          type: string
+          example: "restaurant"
+        color:
+          type: string
+          example: "#F44336"
+
+    PeriodComparison:
+      type: object
+      required:
+        - previousPeriod
+        - change
+      properties:
+        previousPeriod:
+          $ref: '#/components/schemas/PreviousPeriodSummary'
+        change:
+          $ref: '#/components/schemas/PeriodChange'
+
+    PreviousPeriodSummary:
+      type: object
+      required:
+        - startDate
+        - endDate
+        - income
+        - expenses
+        - net
+      properties:
+        startDate:
+          type: string
+          format: date
+          example: "2025-12-01"
+        endDate:
+          type: string
+          format: date
+          example: "2025-12-31"
+        income:
+          type: number
+          format: decimal
+          example: 4500.00
+        expenses:
+          type: number
+          format: decimal
+          example: 2800.00
+        net:
+          type: number
+          format: decimal
+          example: 1700.00
+
+    PeriodChange:
+      type: object
+      required:
+        - income
+        - expenses
+        - net
+      properties:
+        income:
+          type: string
+          description: Percentage change in income (formatted string)
+          example: "+11.1%"
+        expenses:
+          type: string
+          description: Percentage change in expenses (formatted string)
+          example: "+16.1%"
+        net:
+          type: string
+          description: Percentage change in net balance (formatted string)
+          example: "+2.9%"
+
+    # ==================== Error DTOs ====================
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+        - message
+        - timestamp
+        - path
+      properties:
+        error:
+          type: string
+          description: Error code for programmatic handling
+          enum:
+            - BAD_REQUEST
+            - VALIDATION_ERROR
+            - UNAUTHORIZED
+            - FORBIDDEN
+            - NOT_FOUND
+            - CONFLICT
+            - TOO_MANY_REQUESTS
+            - INTERNAL_SERVER_ERROR
+          example: "VALIDATION_ERROR"
+        message:
+          type: string
+          description: Human-readable error message
+          example: "Validation failed"
+        timestamp:
+          type: string
+          format: date-time
+          description: When the error occurred
+          example: "2026-01-23T10:30:00Z"
+        path:
+          type: string
+          description: The API path that was called
+          example: "/api/v1/transactions"
+        requestId:
+          type: string
+          format: uuid
+          description: Request identifier for troubleshooting
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        fieldErrors:
+          type: array
+          description: Field-level validation errors (present for VALIDATION_ERROR)
+          items:
+            $ref: '#/components/schemas/FieldError'
+
+    FieldError:
+      type: object
+      required:
+        - field
+        - message
+        - code
+      properties:
+        field:
+          type: string
+          description: The field that failed validation
+          example: "amount"
+        message:
+          type: string
+          description: Human-readable error message
+          example: "Amount must be greater than 0"
+        code:
+          type: string
+          description: Error code for programmatic handling
+          example: "amount.positive"
+        rejectedValue:
+          type: string
+          nullable: true
+          description: The value that was rejected
+          example: "-50.00"
+
+  responses:
+    BadRequest:
+      description: Invalid request body or parameters
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            validationError:
+              summary: Field validation error
+              value:
+                error: "VALIDATION_ERROR"
+                message: "Validation failed"
+                timestamp: "2026-01-23T10:30:00Z"
+                path: "/api/v1/transactions"
+                fieldErrors:
+                  - field: "amount"
+                    message: "Amount must be greater than 0"
+                    code: "amount.positive"
+                  - field: "categoryId"
+                    message: "Category is required"
+                    code: "category.required"
+            invalidDateRange:
+              summary: Invalid date range
+              value:
+                error: "BAD_REQUEST"
+                message: "Start date must be before or equal to end date"
+                timestamp: "2026-01-23T10:30:00Z"
+                path: "/api/v1/transactions"
+
+    Unauthorized:
+      description: Authentication required or invalid credentials
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/X-Request-ID'
+        WWW-Authenticate:
+          description: Authentication challenge
+          schema:
+            type: string
+          example: "Bearer realm=\"pfwa\", error=\"invalid_token\""
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "UNAUTHORIZED"
+            message: "Authentication required"
+            timestamp: "2026-01-23T10:30:00Z"
+            path: "/api/v1/transactions"
+
+    Forbidden:
+      description: Insufficient permissions or resource belongs to another user
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "FORBIDDEN"
+            message: "You do not have permission to access this transaction"
+            timestamp: "2026-01-23T10:30:00Z"
+            path: "/api/v1/transactions/550e8400-e29b-41d4-a716-446655440000"
+
+    NotFound:
+      description: Resource not found
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "NOT_FOUND"
+            message: "Transaction not found"
+            timestamp: "2026-01-23T10:30:00Z"
+            path: "/api/v1/transactions/550e8400-e29b-41d4-a716-446655440000"
+
+    TooManyRequests:
+      description: Rate limit exceeded
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/X-Request-ID'
+        Retry-After:
+          description: Seconds until the rate limit resets
+          schema:
+            type: integer
+          example: 60
+        X-RateLimit-Limit:
+          description: Request limit per window
+          schema:
+            type: integer
+          example: 60
+        X-RateLimit-Remaining:
+          description: Remaining requests in current window
+          schema:
+            type: integer
+          example: 0
+        X-RateLimit-Reset:
+          description: Unix timestamp when the rate limit resets
+          schema:
+            type: integer
+          example: 1705833060
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "TOO_MANY_REQUESTS"
+            message: "Too many requests. Please try again later."
+            timestamp: "2026-01-23T10:30:00Z"
+            path: "/api/v1/transactions"
+
+    InternalServerError:
+      description: Unexpected server error
+      headers:
+        X-Request-ID:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "INTERNAL_SERVER_ERROR"
+            message: "An unexpected error occurred. Please try again later."
+            timestamp: "2026-01-23T10:30:00Z"
+            path: "/api/v1/transactions"
+            requestId: "550e8400-e29b-41d4-a716-446655440000"

--- a/docs/architecture/adrs/ADR-002-transaction-architecture.md
+++ b/docs/architecture/adrs/ADR-002-transaction-architecture.md
@@ -1,0 +1,872 @@
+# ADR-002: Transaction Architecture for PFWA
+
+## Status
+
+**Accepted**
+
+Date: 2026-01-23
+
+## Context
+
+The Personal Finance Web Application (PFWA) requires a robust transaction management system to track user income and expenses. This system is the core financial data model that other features (budgets, reports, insights) will depend on.
+
+### Requirements
+
+1. **CRUD Operations**: Full create, read, update, delete functionality for transactions
+2. **Categorization**: Each transaction must belong to a category matching its type
+3. **Filtering & Search**: Support complex filtering by date, type, category, amount, and text search
+4. **Pagination & Sorting**: Efficient handling of large transaction sets
+5. **Summary Statistics**: Real-time calculations for totals, breakdowns, and comparisons
+6. **Security**: Users can only access their own transactions
+7. **Data Integrity**: Enforce business rules at application and database levels
+8. **Performance**: Sub-500ms response times for list operations with 1000+ transactions
+
+### Options Considered
+
+#### Option 1: Simple CRUD with In-Memory Filtering
+
+Fetch all user transactions and filter/sort in application memory.
+
+**Pros:**
+- Simple implementation
+- Flexible filtering logic
+- No complex SQL queries
+
+**Cons:**
+- Poor performance with large datasets
+- High memory usage
+- Pagination breaks with in-memory filtering
+- Not scalable
+
+#### Option 2: Spring Data JPA Specifications with Database Filtering
+
+Use Spring Data JPA Specifications for dynamic query building with database-level filtering.
+
+**Pros:**
+- Filtering done at database level (efficient)
+- Type-safe query building
+- Integrates well with Spring Data pagination
+- Good performance with proper indexes
+
+**Cons:**
+- Moderate complexity for dynamic filters
+- Need to manage query optimization
+- Specifications can become verbose
+
+#### Option 3: QueryDSL with Spring Data JPA
+
+Use QueryDSL for type-safe, fluent dynamic query building.
+
+**Pros:**
+- Highly readable, fluent API
+- Type-safe with generated Q-classes
+- Excellent IDE support
+- Powerful predicate composition
+
+**Cons:**
+- Additional build-time code generation
+- Extra dependency
+- Learning curve for team
+
+## Decision
+
+We will implement **Spring Data JPA Specifications with database-level filtering** (Option 2), with the possibility of migrating to QueryDSL in the future if complexity warrants it.
+
+### Architecture Overview
+
+```
++----------------+     +------------------+     +-------------------+
+|   React SPA    |     |   Spring Boot    |     |    PostgreSQL     |
+|                |     |                  |     |                   |
+|  Transaction   |     |  Transaction     |     |  transactions     |
+|  Components    +---->+  Controller      +---->+  table            |
+|                |     |       |          |     |                   |
+|  Filter Panel  |     |       v          |     |  categories       |
+|                |     |  Transaction     |     |  table            |
+|  Data Grid     |     |  Service         |     |                   |
+|                |     |       |          |     |  indexes          |
++----------------+     |       v          |     |                   |
+                       |  Transaction     |     +-------------------+
+                       |  Repository      |
+                       |  (JPA + Specs)   |
+                       +------------------+
+```
+
+### Layered Architecture
+
+#### Controller Layer
+
+The `TransactionController` handles HTTP requests and delegates to the service layer.
+
+```java
+@RestController
+@RequestMapping("/api/v1/transactions")
+@RequiredArgsConstructor
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    @GetMapping
+    public ResponseEntity<TransactionListResponse> listTransactions(
+            @Valid TransactionFilterRequest filter,
+            @PageableDefault(size = 20, sort = "date", direction = DESC) Pageable pageable,
+            @AuthenticationPrincipal UserPrincipal user) {
+
+        return ResponseEntity.ok(
+            transactionService.findTransactions(user.getId(), filter, pageable)
+        );
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TransactionResponse createTransaction(
+            @Valid @RequestBody CreateTransactionRequest request,
+            @AuthenticationPrincipal UserPrincipal user) {
+
+        return transactionService.createTransaction(user.getId(), request);
+    }
+
+    @PutMapping("/{id}")
+    public TransactionResponse updateTransaction(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateTransactionRequest request,
+            @AuthenticationPrincipal UserPrincipal user) {
+
+        return transactionService.updateTransaction(user.getId(), id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteTransaction(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal UserPrincipal user) {
+
+        transactionService.deleteTransaction(user.getId(), id);
+    }
+}
+```
+
+#### Service Layer
+
+The `TransactionService` contains business logic and coordinates between controller and repository.
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+    private final CategoryRepository categoryRepository;
+    private final TransactionMapper transactionMapper;
+
+    public TransactionListResponse findTransactions(
+            UUID userId, TransactionFilterRequest filter, Pageable pageable) {
+
+        Specification<Transaction> spec = TransactionSpecifications
+            .forUser(userId)
+            .and(TransactionSpecifications.withFilters(filter));
+
+        Page<Transaction> page = transactionRepository.findAll(spec, pageable);
+        TransactionListSummary summary = calculateSummary(userId, filter);
+
+        return transactionMapper.toListResponse(page, summary, filter);
+    }
+
+    @Transactional
+    public TransactionResponse createTransaction(UUID userId, CreateTransactionRequest request) {
+        Category category = categoryRepository.findById(request.getCategoryId())
+            .orElseThrow(() -> new CategoryNotFoundException(request.getCategoryId()));
+
+        validateCategoryTypeMatch(request.getType(), category.getType());
+
+        Transaction transaction = transactionMapper.toEntity(request);
+        transaction.setUserId(userId);
+        transaction.setCategory(category);
+
+        Transaction saved = transactionRepository.save(transaction);
+        return transactionMapper.toResponse(saved);
+    }
+
+    @Transactional
+    public TransactionResponse updateTransaction(
+            UUID userId, UUID transactionId, UpdateTransactionRequest request) {
+
+        Transaction transaction = findUserTransaction(userId, transactionId);
+
+        if (!transaction.getCategoryId().equals(request.getCategoryId())) {
+            Category newCategory = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new CategoryNotFoundException(request.getCategoryId()));
+            validateCategoryTypeMatch(request.getType(), newCategory.getType());
+            transaction.setCategory(newCategory);
+        }
+
+        transactionMapper.updateEntity(request, transaction);
+        Transaction updated = transactionRepository.save(transaction);
+        return transactionMapper.toResponse(updated);
+    }
+
+    @Transactional
+    public void deleteTransaction(UUID userId, UUID transactionId) {
+        Transaction transaction = findUserTransaction(userId, transactionId);
+        transactionRepository.delete(transaction);
+    }
+
+    private Transaction findUserTransaction(UUID userId, UUID transactionId) {
+        return transactionRepository.findByIdAndUserId(transactionId, userId)
+            .orElseThrow(() -> new TransactionNotFoundException(transactionId));
+    }
+
+    private void validateCategoryTypeMatch(TransactionType txnType, TransactionType catType) {
+        if (txnType != catType) {
+            throw new CategoryTypeMismatchException(txnType, catType);
+        }
+    }
+}
+```
+
+#### Repository Layer
+
+The `TransactionRepository` extends Spring Data JPA with custom queries.
+
+```java
+@Repository
+public interface TransactionRepository extends
+        JpaRepository<Transaction, UUID>,
+        JpaSpecificationExecutor<Transaction> {
+
+    Optional<Transaction> findByIdAndUserId(UUID id, UUID userId);
+
+    @Query("""
+        SELECT NEW com.pfwa.dto.TransactionSummaryDto(
+            COALESCE(SUM(CASE WHEN t.type = 'INCOME' THEN t.amount ELSE 0 END), 0),
+            COALESCE(SUM(CASE WHEN t.type = 'EXPENSE' THEN t.amount ELSE 0 END), 0),
+            COUNT(t)
+        )
+        FROM Transaction t
+        WHERE t.userId = :userId
+        AND (:startDate IS NULL OR t.date >= :startDate)
+        AND (:endDate IS NULL OR t.date <= :endDate)
+        """)
+    TransactionSummaryDto calculateSummary(
+        @Param("userId") UUID userId,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
+    );
+
+    @Query("""
+        SELECT NEW com.pfwa.dto.CategoryBreakdownDto(
+            t.category.id,
+            t.category.name,
+            t.category.icon,
+            t.category.color,
+            t.type,
+            SUM(t.amount),
+            COUNT(t)
+        )
+        FROM Transaction t
+        WHERE t.userId = :userId
+        AND (:startDate IS NULL OR t.date >= :startDate)
+        AND (:endDate IS NULL OR t.date <= :endDate)
+        GROUP BY t.category.id, t.category.name, t.category.icon, t.category.color, t.type
+        ORDER BY SUM(t.amount) DESC
+        """)
+    List<CategoryBreakdownDto> getCategoryBreakdown(
+        @Param("userId") UUID userId,
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
+    );
+}
+```
+
+#### Specification Layer
+
+Dynamic query building using Spring Data JPA Specifications.
+
+```java
+public class TransactionSpecifications {
+
+    public static Specification<Transaction> forUser(UUID userId) {
+        return (root, query, cb) -> cb.equal(root.get("userId"), userId);
+    }
+
+    public static Specification<Transaction> withFilters(TransactionFilterRequest filter) {
+        return Specification.where(dateRange(filter.getStartDate(), filter.getEndDate()))
+            .and(transactionType(filter.getType()))
+            .and(categories(filter.getCategoryIds()))
+            .and(amountRange(filter.getMinAmount(), filter.getMaxAmount()))
+            .and(searchText(filter.getSearch()));
+    }
+
+    private static Specification<Transaction> dateRange(LocalDate start, LocalDate end) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (start != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("date"), start));
+            }
+            if (end != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("date"), end));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private static Specification<Transaction> transactionType(TransactionType type) {
+        return (root, query, cb) ->
+            type == null ? null : cb.equal(root.get("type"), type);
+    }
+
+    private static Specification<Transaction> categories(List<UUID> categoryIds) {
+        return (root, query, cb) ->
+            categoryIds == null || categoryIds.isEmpty()
+                ? null
+                : root.get("category").get("id").in(categoryIds);
+    }
+
+    private static Specification<Transaction> amountRange(BigDecimal min, BigDecimal max) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (min != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("amount"), min));
+            }
+            if (max != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("amount"), max));
+            }
+            return predicates.isEmpty() ? null : cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private static Specification<Transaction> searchText(String search) {
+        return (root, query, cb) -> {
+            if (search == null || search.length() < 2) {
+                return null;
+            }
+            String pattern = "%" + search.toLowerCase() + "%";
+            return cb.or(
+                cb.like(cb.lower(root.get("description")), pattern),
+                cb.like(cb.lower(root.get("notes")), pattern)
+            );
+        };
+    }
+}
+```
+
+### Entity Design
+
+```java
+@Entity
+@Table(name = "transactions", indexes = {
+    @Index(name = "idx_transactions_user_id", columnList = "user_id"),
+    @Index(name = "idx_transactions_user_date", columnList = "user_id, date DESC"),
+    @Index(name = "idx_transactions_category_id", columnList = "category_id"),
+    @Index(name = "idx_transactions_type", columnList = "type")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(nullable = false, precision = 12, scale = 2)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(length = 1000)
+    private String notes;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    @UpdateTimestamp
+    private Instant updatedAt;
+}
+
+@Entity
+@Table(name = "categories", indexes = {
+    @Index(name = "idx_categories_type", columnList = "type")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TransactionType type;
+
+    @Column(length = 50)
+    private String icon;
+
+    @Column(length = 7)
+    private String color;
+
+    @Column(name = "display_order")
+    private Integer displayOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreationTimestamp
+    private Instant createdAt;
+}
+```
+
+### Database Schema
+
+```sql
+-- Transactions table
+CREATE TABLE transactions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    amount DECIMAL(12,2) NOT NULL CHECK (amount > 0),
+    type VARCHAR(20) NOT NULL CHECK (type IN ('INCOME', 'EXPENSE')),
+    category_id UUID NOT NULL REFERENCES categories(id),
+    date DATE NOT NULL,
+    description VARCHAR(500),
+    notes VARCHAR(1000),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Performance indexes
+CREATE INDEX idx_transactions_user_id ON transactions(user_id);
+CREATE INDEX idx_transactions_user_date ON transactions(user_id, date DESC);
+CREATE INDEX idx_transactions_category_id ON transactions(category_id);
+CREATE INDEX idx_transactions_type ON transactions(type);
+
+-- Full-text search index (PostgreSQL specific)
+CREATE INDEX idx_transactions_description_gin ON transactions
+    USING gin(to_tsvector('english', COALESCE(description, '') || ' ' || COALESCE(notes, '')));
+
+-- Categories table
+CREATE TABLE categories (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL,
+    type VARCHAR(20) NOT NULL CHECK (type IN ('INCOME', 'EXPENSE')),
+    icon VARCHAR(50),
+    color VARCHAR(7),
+    display_order INT DEFAULT 0,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_categories_type ON categories(type);
+CREATE INDEX idx_categories_active ON categories(is_active) WHERE is_active = true;
+```
+
+### Validation Strategy
+
+#### Request Validation (Bean Validation)
+
+```java
+public class CreateTransactionRequest {
+
+    @NotNull(message = "Amount is required")
+    @DecimalMin(value = "0.01", message = "Amount must be greater than 0")
+    @DecimalMax(value = "10000000", message = "Amount exceeds maximum allowed value")
+    @Digits(integer = 10, fraction = 2, message = "Amount must have at most 2 decimal places")
+    private BigDecimal amount;
+
+    @NotNull(message = "Transaction type is required")
+    private TransactionType type;
+
+    @NotNull(message = "Category is required")
+    private UUID categoryId;
+
+    @NotNull(message = "Date is required")
+    @PastOrPresent(message = "Date cannot be in the future")
+    private LocalDate date;
+
+    @Size(max = 500, message = "Description must be 500 characters or less")
+    private String description;
+
+    @Size(max = 1000, message = "Notes must be 1000 characters or less")
+    private String notes;
+}
+```
+
+#### Business Rule Validation
+
+```java
+@Service
+public class TransactionValidator {
+
+    private static final int MAX_PAST_DAYS = 365;
+
+    public void validateTransaction(CreateTransactionRequest request, Category category) {
+        List<String> errors = new ArrayList<>();
+
+        // Category type must match transaction type
+        if (request.getType() != category.getType()) {
+            errors.add("Category type must match transaction type");
+        }
+
+        // Date cannot be more than 1 year in the past
+        if (request.getDate().isBefore(LocalDate.now().minusDays(MAX_PAST_DAYS))) {
+            errors.add("Transaction date cannot be more than 1 year in the past");
+        }
+
+        // Category must be active
+        if (!category.isActive()) {
+            errors.add("Selected category is no longer available");
+        }
+
+        if (!errors.isEmpty()) {
+            throw new BusinessValidationException(errors);
+        }
+    }
+}
+```
+
+### Security Implementation
+
+#### User Isolation
+
+All transaction queries are scoped to the authenticated user:
+
+```java
+// Always filter by user ID at repository level
+Specification<Transaction> spec = TransactionSpecifications.forUser(userId)
+    .and(TransactionSpecifications.withFilters(filter));
+```
+
+#### Authorization Checks
+
+```java
+@PreAuthorize("isAuthenticated()")
+public class TransactionController {
+
+    @GetMapping("/{id}")
+    public TransactionResponse getTransaction(@PathVariable UUID id, @AuthenticationPrincipal UserPrincipal user) {
+        Transaction transaction = transactionRepository.findByIdAndUserId(id, user.getId())
+            .orElseThrow(() -> new TransactionNotFoundException(id));
+        return transactionMapper.toResponse(transaction);
+    }
+}
+```
+
+### Performance Optimizations
+
+#### Database Indexes
+
+```sql
+-- Composite index for user + date filtering (most common query pattern)
+CREATE INDEX idx_transactions_user_date ON transactions(user_id, date DESC);
+
+-- Index for category filtering
+CREATE INDEX idx_transactions_category_id ON transactions(category_id);
+
+-- Index for type filtering
+CREATE INDEX idx_transactions_type ON transactions(type);
+
+-- Partial index for amount range queries
+CREATE INDEX idx_transactions_amount ON transactions(amount)
+    WHERE amount > 0;
+```
+
+#### Query Optimization
+
+```java
+// Fetch categories in batch to avoid N+1
+@EntityGraph(attributePaths = {"category"})
+Page<Transaction> findAll(Specification<Transaction> spec, Pageable pageable);
+
+// Summary query with single database round trip
+@Query("SELECT NEW ... FROM Transaction t WHERE ... GROUP BY ...")
+TransactionSummaryDto calculateSummary(...);
+```
+
+#### Pagination Limits
+
+```java
+@Configuration
+public class PaginationConfig {
+
+    public static final int DEFAULT_PAGE_SIZE = 20;
+    public static final int MAX_PAGE_SIZE = 100;
+
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer paginationCustomizer() {
+        return resolver -> {
+            resolver.setMaxPageSize(MAX_PAGE_SIZE);
+            resolver.setFallbackPageable(PageRequest.of(0, DEFAULT_PAGE_SIZE));
+        };
+    }
+}
+```
+
+### DTO Mapping with MapStruct
+
+```java
+@Mapper(componentModel = "spring")
+public interface TransactionMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "category", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    Transaction toEntity(CreateTransactionRequest request);
+
+    @Mapping(source = "category.id", target = "category.id")
+    @Mapping(source = "category.name", target = "category.name")
+    @Mapping(source = "category.type", target = "category.type")
+    @Mapping(source = "category.icon", target = "category.icon")
+    @Mapping(source = "category.color", target = "category.color")
+    TransactionResponse toResponse(Transaction transaction);
+
+    default TransactionListResponse toListResponse(
+            Page<Transaction> page,
+            TransactionListSummary summary,
+            TransactionFilterRequest appliedFilters) {
+
+        return TransactionListResponse.builder()
+            .content(page.getContent().stream().map(this::toResponse).toList())
+            .page(page.getNumber())
+            .size(page.getSize())
+            .totalElements(page.getTotalElements())
+            .totalPages(page.getTotalPages())
+            .first(page.isFirst())
+            .last(page.isLast())
+            .summary(summary)
+            .appliedFilters(appliedFilters)
+            .build();
+    }
+
+    void updateEntity(UpdateTransactionRequest request, @MappingTarget Transaction transaction);
+}
+```
+
+### Rate Limiting Strategy
+
+| Endpoint | Limit | Window |
+|----------|-------|--------|
+| GET /transactions | 60 requests | 1 minute |
+| POST /transactions | 30 requests | 1 minute |
+| PUT /transactions/{id} | 30 requests | 1 minute |
+| DELETE /transactions/{id} | 30 requests | 1 minute |
+| GET /transactions/summary | 30 requests | 1 minute |
+| GET /categories | 60 requests | 1 minute |
+
+### Error Handling
+
+```java
+@RestControllerAdvice
+public class TransactionExceptionHandler {
+
+    @ExceptionHandler(TransactionNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleTransactionNotFound(
+            TransactionNotFoundException ex, HttpServletRequest request) {
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(ErrorResponse.builder()
+                .error("NOT_FOUND")
+                .message("Transaction not found")
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .build());
+    }
+
+    @ExceptionHandler(CategoryTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleCategoryTypeMismatch(
+            CategoryTypeMismatchException ex, HttpServletRequest request) {
+
+        return ResponseEntity.badRequest()
+            .body(ErrorResponse.builder()
+                .error("VALIDATION_ERROR")
+                .message("Validation failed")
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .fieldErrors(List.of(
+                    FieldError.builder()
+                        .field("categoryId")
+                        .message("Category type must match transaction type")
+                        .code("category.type.mismatch")
+                        .build()
+                ))
+                .build());
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(
+            AccessDeniedException ex, HttpServletRequest request) {
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(ErrorResponse.builder()
+                .error("FORBIDDEN")
+                .message("You do not have permission to access this transaction")
+                .timestamp(Instant.now())
+                .path(request.getRequestURI())
+                .build());
+    }
+}
+```
+
+## Consequences
+
+### Positive
+
+1. **Performance**: Database-level filtering with proper indexes ensures fast queries even with large datasets
+2. **Security**: User isolation at repository level prevents unauthorized data access
+3. **Maintainability**: Clear separation of concerns across layers
+4. **Type Safety**: Compile-time checking with Spring Data JPA Specifications
+5. **Flexibility**: Easy to add new filter criteria without changing core logic
+6. **Testability**: Each layer can be unit tested independently
+7. **Standards Compliance**: RESTful API design with proper HTTP status codes
+
+### Negative
+
+1. **Complexity**: More code than simple CRUD operations
+2. **Learning Curve**: Team needs to understand Specifications pattern
+3. **Query Optimization**: Need to monitor and tune queries as data grows
+4. **Eager Loading**: Must be careful to avoid N+1 queries
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| N+1 query problems | Use `@EntityGraph` for eager loading of categories |
+| Full-text search performance | PostgreSQL GIN indexes, consider Elasticsearch for future |
+| Summary calculation bottleneck | Database aggregation queries, cache for frequent periods |
+| Large pagination offset | Keyset pagination for deep pages (future enhancement) |
+| Concurrent updates | Optimistic locking with `@Version` (future enhancement) |
+
+## Implementation Notes
+
+### Dependencies
+
+```xml
+<!-- pom.xml -->
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-data-jpa</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-validation</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.mapstruct</groupId>
+    <artifactId>mapstruct</artifactId>
+    <version>1.5.5.Final</version>
+</dependency>
+<dependency>
+    <groupId>org.mapstruct</groupId>
+    <artifactId>mapstruct-processor</artifactId>
+    <version>1.5.5.Final</version>
+    <scope>provided</scope>
+</dependency>
+```
+
+### Environment Variables
+
+```properties
+# Pagination
+DEFAULT_PAGE_SIZE=20
+MAX_PAGE_SIZE=100
+
+# Validation
+MAX_TRANSACTION_AMOUNT=10000000
+MAX_DESCRIPTION_LENGTH=500
+MAX_NOTES_LENGTH=1000
+MAX_PAST_DAYS=365
+
+# Rate Limiting
+RATE_LIMIT_TRANSACTIONS_READ=60
+RATE_LIMIT_TRANSACTIONS_WRITE=30
+```
+
+### Testing Strategy
+
+1. **Unit Tests**: Service layer with mocked repository
+2. **Integration Tests**: Repository layer with embedded PostgreSQL (Testcontainers)
+3. **API Tests**: Controller layer with MockMvc
+4. **E2E Tests**: Full stack tests with Cypress
+
+Example test:
+
+```java
+@SpringBootTest
+@AutoConfigureMockMvc
+class TransactionControllerTest {
+
+    @Test
+    @WithMockUser
+    void createTransaction_ValidRequest_ReturnsCreated() throws Exception {
+        CreateTransactionRequest request = CreateTransactionRequest.builder()
+            .amount(new BigDecimal("150.00"))
+            .type(TransactionType.EXPENSE)
+            .categoryId(UUID.randomUUID())
+            .date(LocalDate.now())
+            .description("Test transaction")
+            .build();
+
+        mockMvc.perform(post("/api/v1/transactions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.amount").value(150.00))
+            .andExpect(jsonPath("$.type").value("EXPENSE"));
+    }
+
+    @Test
+    @WithMockUser
+    void listTransactions_WithFilters_ReturnsFilteredResults() throws Exception {
+        mockMvc.perform(get("/api/v1/transactions")
+                .param("type", "EXPENSE")
+                .param("startDate", "2026-01-01")
+                .param("endDate", "2026-01-31"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.summary.totalExpenses").exists());
+    }
+}
+```
+
+## References
+
+- [Spring Data JPA Specifications](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#specifications)
+- [MapStruct Documentation](https://mapstruct.org/documentation/stable/reference/html/)
+- [PostgreSQL Indexes](https://www.postgresql.org/docs/current/indexes.html)
+- [REST API Design Best Practices](https://restfulapi.net/)
+- [OWASP Data Validation](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html)
+
+## Related ADRs
+
+- [ADR-001: Authentication Architecture](./ADR-001-authentication-architecture.md) - JWT authentication used for API security
+
+## Changelog
+
+| Date | Author | Description |
+|------|--------|-------------|
+| 2026-01-23 | Architecture Team | Initial version |

--- a/docs/requirements/user-stories/epic-2-transactions.md
+++ b/docs/requirements/user-stories/epic-2-transactions.md
@@ -1,0 +1,1208 @@
+# Epic 2: Transactions User Stories
+
+## Epic Overview
+**Epic ID:** EPIC-002
+**Epic Name:** Transactions
+**Story Points:** 27
+**Priority:** Must Have (MVP Critical)
+**Status:** Ready for Development
+
+### Epic Description
+Implement comprehensive transaction management system allowing users to create, read, update, and delete financial transactions (income and expenses). Include categorization, filtering, search, pagination, and summary features for effective personal finance tracking.
+
+### Technical Stack
+- Backend: Spring Boot REST API, Spring Data JPA
+- Database: PostgreSQL (transactions, categories tables)
+- Frontend: React with Material-UI forms and data grids
+- Validation: Bean Validation (JSR-380), custom business rules
+- Features: Filtering, pagination, sorting, CSV export
+
+---
+
+## User Stories
+
+### TXN-001: Create Transaction
+**Priority:** Must Have
+**Story Points:** 5
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **add a new transaction with amount, type, category, date, and description**,
+So that **I can track my income and expenses accurately**.
+
+#### Acceptance Criteria
+
+**Given** I am on the transaction creation page
+**When** I enter valid transaction details (amount, type, category, date, description)
+**Then** the transaction is saved and I see a success message "Transaction created successfully"
+
+**Given** I am creating a transaction
+**When** I select transaction type as "INCOME"
+**Then** I can choose from income categories (Salary, Freelance, Investments, Other Income)
+
+**Given** I am creating a transaction
+**When** I select transaction type as "EXPENSE"
+**Then** I can choose from expense categories (Food, Transportation, Housing, Utilities, Entertainment, Healthcare, Shopping, Other)
+
+**Given** I am creating a transaction
+**When** I enter an amount less than or equal to 0
+**Then** I see an error message "Amount must be greater than 0"
+
+**Given** I am creating a transaction
+**When** I enter an amount greater than 10,000,000
+**Then** I see an error message "Amount exceeds maximum allowed value"
+
+**Given** I am creating a transaction
+**When** I select a future date beyond today
+**Then** I see a warning "Transaction date is in the future. Are you sure?"
+
+**Given** I am creating a transaction
+**When** I leave required fields empty (amount, type, category, date)
+**Then** I see specific validation errors for each missing field
+
+**Given** I am creating a transaction
+**When** I enter a description longer than 500 characters
+**Then** I see an error message "Description must be 500 characters or less"
+
+**Given** I successfully create a transaction
+**When** the transaction is saved
+**Then** I am redirected to the transaction list with the new transaction visible at the top
+
+#### Technical Requirements
+- Amount: decimal(12,2), positive value required
+- Type: enum (INCOME, EXPENSE)
+- Category: foreign key to categories table
+- Date: date field, default to today, can be past or present
+- Description: optional, varchar(500)
+- User ID: foreign key to authenticated user
+- Created timestamp and updated timestamp auto-generated
+- Validation: amount > 0, date not null, category exists
+
+#### API Endpoint
+```
+POST /api/v1/transactions
+Headers:
+  Authorization: Bearer {accessToken}
+
+Request Body:
+{
+  "amount": 150.00,
+  "type": "EXPENSE",
+  "categoryId": "uuid",
+  "date": "2026-01-20",
+  "description": "Grocery shopping at Whole Foods",
+  "notes": "Weekly groceries"
+}
+
+Response: 201 Created
+{
+  "id": "uuid",
+  "amount": 150.00,
+  "type": "EXPENSE",
+  "category": {
+    "id": "uuid",
+    "name": "Food",
+    "type": "EXPENSE"
+  },
+  "date": "2026-01-20",
+  "description": "Grocery shopping at Whole Foods",
+  "notes": "Weekly groceries",
+  "createdAt": "2026-01-20T14:30:00Z",
+  "updatedAt": "2026-01-20T14:30:00Z"
+}
+```
+
+---
+
+### TXN-002: View Transaction List
+**Priority:** Must Have
+**Story Points:** 3
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **see a list of all my transactions sorted by date (newest first)**,
+So that **I can review my recent financial activity**.
+
+#### Acceptance Criteria
+
+**Given** I navigate to the transactions page
+**When** the page loads
+**Then** I see my transactions sorted by date (most recent first)
+
+**Given** I have no transactions
+**When** I view the transactions page
+**Then** I see a message "No transactions yet. Create your first transaction to get started."
+
+**Given** I have transactions
+**When** I view the transaction list
+**Then** each transaction displays:
+- Amount (formatted with currency symbol)
+- Type indicator (income in green, expense in red)
+- Category name with icon
+- Date (formatted as MMM DD, YYYY)
+- Description (truncated if longer than 50 chars)
+- Actions (Edit, Delete buttons)
+
+**Given** I have more than 20 transactions
+**When** I view the transaction list
+**Then** I see 20 transactions per page with pagination controls
+
+**Given** I am viewing the transaction list
+**When** I click on a transaction row
+**Then** I see an expanded view with full details including notes and timestamps
+
+**Given** I am viewing the transaction list
+**When** I have both income and expenses
+**Then** I see a summary at the top showing total income, total expenses, and net balance for the current view
+
+#### Technical Requirements
+- Default sort: date DESC, createdAt DESC
+- Pagination: 20 items per page
+- Response includes total count for pagination
+- Include category details in response
+- Amount formatted with 2 decimal places
+- User can only see their own transactions (security filter)
+
+#### API Endpoint
+```
+GET /api/v1/transactions?page=0&size=20&sort=date,desc
+Headers:
+  Authorization: Bearer {accessToken}
+
+Response: 200 OK
+{
+  "content": [
+    {
+      "id": "uuid",
+      "amount": 150.00,
+      "type": "EXPENSE",
+      "category": {
+        "id": "uuid",
+        "name": "Food",
+        "type": "EXPENSE",
+        "icon": "restaurant"
+      },
+      "date": "2026-01-20",
+      "description": "Grocery shopping",
+      "createdAt": "2026-01-20T14:30:00Z"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 125,
+  "totalPages": 7,
+  "summary": {
+    "totalIncome": 5000.00,
+    "totalExpenses": 3250.50,
+    "netBalance": 1749.50
+  }
+}
+```
+
+---
+
+### TXN-003: Edit Transaction
+**Priority:** Must Have
+**Story Points:** 3
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **edit an existing transaction's details**,
+So that **I can correct mistakes or update information**.
+
+#### Acceptance Criteria
+
+**Given** I am viewing a transaction
+**When** I click the "Edit" button
+**Then** I see a form pre-filled with the current transaction details
+
+**Given** I am editing a transaction
+**When** I modify any field (amount, category, date, description) and save
+**Then** the transaction is updated with the new values and I see "Transaction updated successfully"
+
+**Given** I am editing a transaction
+**When** I change the amount to an invalid value (negative or zero)
+**Then** I see the same validation errors as transaction creation
+
+**Given** I am editing a transaction
+**When** I change the type from INCOME to EXPENSE
+**Then** the category dropdown updates to show expense categories only
+
+**Given** I am editing a transaction
+**When** I click "Cancel"
+**Then** no changes are saved and I return to the transaction list
+
+**Given** I try to edit a transaction
+**When** the transaction belongs to another user
+**Then** I receive a 403 Forbidden error
+
+**Given** I successfully update a transaction
+**When** the save completes
+**Then** the updatedAt timestamp reflects the current time
+
+#### Technical Requirements
+- Load current transaction data for edit form
+- Validate user owns the transaction before allowing update
+- Same validation rules as creation
+- Update updatedAt timestamp automatically
+- Return updated transaction in response
+- Optimistic locking to prevent concurrent update conflicts (optional)
+
+#### API Endpoint
+```
+PUT /api/v1/transactions/{id}
+Headers:
+  Authorization: Bearer {accessToken}
+
+Request Body:
+{
+  "amount": 175.00,
+  "type": "EXPENSE",
+  "categoryId": "uuid",
+  "date": "2026-01-20",
+  "description": "Updated description",
+  "notes": "Updated notes"
+}
+
+Response: 200 OK
+{
+  "id": "uuid",
+  "amount": 175.00,
+  "type": "EXPENSE",
+  "category": {
+    "id": "uuid",
+    "name": "Food",
+    "type": "EXPENSE"
+  },
+  "date": "2026-01-20",
+  "description": "Updated description",
+  "notes": "Updated notes",
+  "createdAt": "2026-01-20T14:30:00Z",
+  "updatedAt": "2026-01-20T15:45:00Z"
+}
+```
+
+---
+
+### TXN-004: Delete Transaction
+**Priority:** Must Have
+**Story Points:** 2
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **delete a transaction**,
+So that **I can remove incorrect or duplicate entries**.
+
+#### Acceptance Criteria
+
+**Given** I am viewing a transaction
+**When** I click the "Delete" button
+**Then** I see a confirmation dialog "Are you sure you want to delete this transaction? This action cannot be undone."
+
+**Given** I see the delete confirmation dialog
+**When** I click "Confirm"
+**Then** the transaction is permanently deleted and I see "Transaction deleted successfully"
+
+**Given** I see the delete confirmation dialog
+**When** I click "Cancel"
+**Then** the transaction is not deleted and the dialog closes
+
+**Given** I try to delete a transaction
+**When** the transaction belongs to another user
+**Then** I receive a 403 Forbidden error
+
+**Given** I delete a transaction
+**When** the transaction is part of budget tracking
+**Then** budget progress is recalculated automatically to reflect the deletion
+
+**Given** I delete a transaction
+**When** the deletion is successful
+**Then** the transaction is removed from the list immediately (optimistic UI update)
+
+#### Technical Requirements
+- Soft delete option for audit trail (mark as deleted, don't remove from DB)
+- Hard delete for MVP (actually remove from database)
+- Validate user owns the transaction before deletion
+- Cascade considerations: update budget totals if applicable
+- Return 204 No Content on successful deletion
+- Transaction deletion triggers budget recalculation job
+
+#### API Endpoint
+```
+DELETE /api/v1/transactions/{id}
+Headers:
+  Authorization: Bearer {accessToken}
+
+Response: 204 No Content
+```
+
+---
+
+### TXN-005: Filter Transactions
+**Priority:** Must Have
+**Story Points:** 5
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **filter my transactions by date range, category, type, and amount range**,
+So that **I can find specific transactions and analyze spending patterns**.
+
+#### Acceptance Criteria
+
+**Given** I am on the transactions page
+**When** I open the filter panel
+**Then** I see filter options for: date range, type, category, and amount range
+
+**Given** I apply a date range filter
+**When** I select "Last 30 days"
+**Then** I see only transactions from the past 30 days
+
+**Given** I apply a type filter
+**When** I select "EXPENSE"
+**Then** I see only expense transactions (no income transactions)
+
+**Given** I apply a category filter
+**When** I select "Food"
+**Then** I see only transactions in the Food category
+
+**Given** I apply an amount range filter
+**When** I set minimum 50 and maximum 200
+**Then** I see only transactions with amounts between 50 and 200 (inclusive)
+
+**Given** I apply multiple filters
+**When** I select date range "Last 7 days", type "EXPENSE", and category "Food"
+**Then** I see only food expense transactions from the last 7 days (AND logic)
+
+**Given** I have applied filters
+**When** I click "Clear Filters"
+**Then** all filters are removed and I see all my transactions again
+
+**Given** I have applied filters
+**When** I view the transaction summary
+**Then** the summary (total income, expenses, net) reflects only the filtered transactions
+
+**Given** I apply filters
+**When** I navigate away and return
+**Then** the filters persist in the URL query parameters and are reapplied
+
+#### Technical Requirements
+- Date range: predefined options (Today, Last 7 days, Last 30 days, This Month, Custom)
+- Custom date range: calendar picker for start and end dates
+- Type: radio buttons (All, Income, Expense)
+- Category: multi-select dropdown (can select multiple categories)
+- Amount range: two number inputs (min and max)
+- Filters combined with AND logic
+- URL query parameters for shareable/bookmarkable filtered views
+- Filter state persists in browser session storage
+- Pagination resets to page 0 when filters change
+
+#### API Endpoint
+```
+GET /api/v1/transactions?startDate=2026-01-01&endDate=2026-01-31&type=EXPENSE&categoryIds=uuid1,uuid2&minAmount=50&maxAmount=200&page=0&size=20&sort=date,desc
+Headers:
+  Authorization: Bearer {accessToken}
+
+Response: 200 OK
+{
+  "content": [...],
+  "page": 0,
+  "size": 20,
+  "totalElements": 45,
+  "totalPages": 3,
+  "summary": {
+    "totalIncome": 0.00,
+    "totalExpenses": 2250.00,
+    "netBalance": -2250.00
+  },
+  "appliedFilters": {
+    "startDate": "2026-01-01",
+    "endDate": "2026-01-31",
+    "type": "EXPENSE",
+    "categoryIds": ["uuid1", "uuid2"],
+    "minAmount": 50,
+    "maxAmount": 200
+  }
+}
+```
+
+---
+
+### TXN-006: Search Transactions
+**Priority:** Should Have
+**Story Points:** 3
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **search for transactions by description or notes**,
+So that **I can quickly find a specific transaction**.
+
+#### Acceptance Criteria
+
+**Given** I am on the transactions page
+**When** I enter a search term in the search box
+**Then** I see transactions that contain the search term in description or notes (case-insensitive)
+
+**Given** I enter "grocery" in the search box
+**When** the search executes
+**Then** I see all transactions with "grocery", "Grocery", or "GROCERY" in the description or notes
+
+**Given** I have a search term entered
+**When** I clear the search box
+**Then** all transactions are displayed again
+
+**Given** I enter a search term
+**When** no transactions match
+**Then** I see "No transactions found matching your search"
+
+**Given** I have both filters and a search term applied
+**When** I view the results
+**Then** I see transactions matching both the search term AND the filters
+
+**Given** I enter a search term
+**When** I wait 300ms after typing stops (debounce)
+**Then** the search executes automatically
+
+**Given** I search for a partial word like "groc"
+**When** the search executes
+**Then** I see transactions containing words starting with "groc" (e.g., "grocery", "groceries")
+
+#### Technical Requirements
+- Search fields: description, notes
+- Case-insensitive search
+- Partial match support (use ILIKE in PostgreSQL)
+- Debounce search input: 300ms delay after typing stops
+- Combine with filters using AND logic
+- Highlight search terms in results (optional, frontend)
+- Search indexed for performance (database index on description)
+- Minimum search length: 2 characters
+
+#### API Endpoint
+```
+GET /api/v1/transactions?search=grocery&page=0&size=20
+Headers:
+  Authorization: Bearer {accessToken}
+
+Response: 200 OK
+{
+  "content": [
+    {
+      "id": "uuid",
+      "amount": 150.00,
+      "type": "EXPENSE",
+      "category": {
+        "id": "uuid",
+        "name": "Food",
+        "type": "EXPENSE"
+      },
+      "date": "2026-01-20",
+      "description": "Grocery shopping at Whole Foods",
+      "notes": "Weekly groceries",
+      "createdAt": "2026-01-20T14:30:00Z"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 8,
+  "totalPages": 1,
+  "summary": {
+    "totalIncome": 0.00,
+    "totalExpenses": 1250.00,
+    "netBalance": -1250.00
+  }
+}
+```
+
+---
+
+### TXN-007: Transaction Categories Management
+**Priority:** Must Have
+**Story Points:** 3
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **view and select from predefined transaction categories**,
+So that **I can consistently categorize my income and expenses**.
+
+#### Acceptance Criteria
+
+**Given** I am creating or editing a transaction
+**When** I select transaction type "INCOME"
+**Then** I see income categories: Salary, Freelance, Investments, Gifts, Refunds, Other Income
+
+**Given** I am creating or editing a transaction
+**When** I select transaction type "EXPENSE"
+**Then** I see expense categories: Food & Dining, Transportation, Housing, Utilities, Entertainment, Healthcare, Shopping, Education, Travel, Personal Care, Subscriptions, Other
+
+**Given** I am viewing the categories dropdown
+**When** the dropdown opens
+**Then** categories are displayed with icons and organized alphabetically
+
+**Given** I am on the transactions page
+**When** I view transactions
+**Then** each transaction displays its category name and icon
+
+**Given** I am viewing transaction statistics
+**When** I group by category
+**Then** uncategorized transactions appear under "Uncategorized" category
+
+#### Technical Requirements
+- Categories table with predefined seed data
+- Category fields: id, name, type (INCOME/EXPENSE), icon, color, display order
+- Categories are system-defined (not user-created in MVP)
+- Categories loaded once and cached on frontend
+- Each transaction must have exactly one category
+- Category soft-delete support (hide but don't remove if transactions exist)
+
+#### API Endpoint
+```
+GET /api/v1/categories
+Headers:
+  Authorization: Bearer {accessToken}
+
+Response: 200 OK
+{
+  "income": [
+    {
+      "id": "uuid",
+      "name": "Salary",
+      "type": "INCOME",
+      "icon": "payments",
+      "color": "#4CAF50"
+    },
+    {
+      "id": "uuid",
+      "name": "Freelance",
+      "type": "INCOME",
+      "icon": "work",
+      "color": "#8BC34A"
+    }
+  ],
+  "expense": [
+    {
+      "id": "uuid",
+      "name": "Food & Dining",
+      "type": "EXPENSE",
+      "icon": "restaurant",
+      "color": "#F44336"
+    },
+    {
+      "id": "uuid",
+      "name": "Transportation",
+      "type": "EXPENSE",
+      "icon": "directions_car",
+      "color": "#E91E63"
+    }
+  ]
+}
+```
+
+---
+
+### TXN-008: Transaction Pagination and Sorting
+**Priority:** Must Have
+**Story Points:** 2
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **navigate through my transactions with pagination and sort by different columns**,
+So that **I can efficiently browse large lists of transactions**.
+
+#### Acceptance Criteria
+
+**Given** I have more than 20 transactions
+**When** I view the transactions page
+**Then** I see pagination controls showing current page, total pages, and navigation buttons
+
+**Given** I am on page 1 of transactions
+**When** I click "Next"
+**Then** I see page 2 with the next 20 transactions
+
+**Given** I am viewing transactions
+**When** I click the "Date" column header
+**Then** transactions are sorted by date in ascending order, and clicking again sorts descending
+
+**Given** I am viewing transactions
+**When** I click the "Amount" column header
+**Then** transactions are sorted by amount (lowest to highest), and clicking again reverses the order
+
+**Given** I am viewing transactions
+**When** I click the "Category" column header
+**Then** transactions are sorted alphabetically by category name
+
+**Given** I am on page 3 of transactions
+**When** I apply a filter
+**Then** pagination resets to page 1 with filtered results
+
+**Given** I am viewing transactions
+**When** I change the page size to 50 items per page
+**Then** I see up to 50 transactions per page and pagination updates accordingly
+
+**Given** I navigate to a specific page
+**When** I refresh the browser
+**Then** I remain on the same page with the same sort order (persisted in URL)
+
+#### Technical Requirements
+- Default pagination: page 0, size 20
+- Supported page sizes: 10, 20, 50, 100
+- Sortable columns: date, amount, category, createdAt
+- Sort direction: asc, desc
+- URL parameters: page, size, sort
+- Show "Showing X-Y of Z transactions"
+- Disable "Previous" on first page, "Next" on last page
+- Jump to page input for quick navigation (optional)
+
+#### API Endpoint
+```
+GET /api/v1/transactions?page=2&size=20&sort=amount,desc
+Headers:
+  Authorization: Bearer {accessToken}
+
+Response: 200 OK
+{
+  "content": [...],
+  "page": 2,
+  "size": 20,
+  "totalElements": 125,
+  "totalPages": 7,
+  "first": false,
+  "last": false,
+  "summary": {
+    "totalIncome": 5000.00,
+    "totalExpenses": 3250.50,
+    "netBalance": 1749.50
+  }
+}
+```
+
+---
+
+### TXN-009: Transaction Summary and Statistics
+**Priority:** Should Have
+**Story Points:** 3
+**Status:** Ready
+
+#### User Story
+As a **logged-in user**,
+I want to **see summary statistics of my transactions including totals by type and category breakdown**,
+So that **I can understand my spending patterns at a glance**.
+
+#### Acceptance Criteria
+
+**Given** I am on the transactions page
+**When** the page loads
+**Then** I see a summary card displaying total income, total expenses, and net balance
+
+**Given** I have filtered transactions
+**When** I view the summary
+**Then** the summary reflects only the filtered transactions
+
+**Given** I am viewing the transaction summary
+**When** I click "View Category Breakdown"
+**Then** I see a breakdown showing total amount and percentage for each category
+
+**Given** I am viewing the category breakdown
+**When** I have both income and expenses
+**Then** I see separate breakdowns for income categories and expense categories
+
+**Given** I am viewing the category breakdown
+**When** I click on a category
+**Then** the transaction list filters to show only transactions in that category
+
+**Given** I select a date range
+**When** I view the summary
+**Then** I see a comparison with the previous period (e.g., "15% increase from last month")
+
+**Given** I am viewing statistics
+**When** I have no transactions
+**Then** I see "No transactions yet" with a call-to-action to create the first transaction
+
+#### Technical Requirements
+- Calculate totals: SUM(amount) WHERE type = 'INCOME', SUM(amount) WHERE type = 'EXPENSE'
+- Net balance: total income - total expenses
+- Category breakdown: GROUP BY category, calculate percentage of total
+- Comparison calculations: compare current period with previous equal-length period
+- Format currency with proper symbols and separators
+- Color coding: green for positive, red for negative, gray for zero
+- Cache summary calculations for performance (optional)
+
+#### API Endpoint
+```
+GET /api/v1/transactions/summary?startDate=2026-01-01&endDate=2026-01-31
+Headers:
+  Authorization: Bearer {accessToken}
+
+Response: 200 OK
+{
+  "period": {
+    "startDate": "2026-01-01",
+    "endDate": "2026-01-31"
+  },
+  "totals": {
+    "income": 5000.00,
+    "expenses": 3250.50,
+    "net": 1749.50,
+    "transactionCount": 87
+  },
+  "categoryBreakdown": {
+    "income": [
+      {
+        "category": {
+          "id": "uuid",
+          "name": "Salary",
+          "icon": "payments"
+        },
+        "total": 4500.00,
+        "percentage": 90.0,
+        "transactionCount": 2
+      }
+    ],
+    "expense": [
+      {
+        "category": {
+          "id": "uuid",
+          "name": "Food & Dining",
+          "icon": "restaurant"
+        },
+        "total": 850.00,
+        "percentage": 26.15,
+        "transactionCount": 18
+      }
+    ]
+  },
+  "comparison": {
+    "previousPeriod": {
+      "income": 4500.00,
+      "expenses": 2800.00,
+      "net": 1700.00
+    },
+    "change": {
+      "income": "+11.1%",
+      "expenses": "+16.1%",
+      "net": "+2.9%"
+    }
+  }
+}
+```
+
+---
+
+### TXN-010: Bulk Operations
+**Priority:** Could Have
+**Story Points:** 5
+**Status:** Backlog
+
+#### User Story
+As a **logged-in user**,
+I want to **select multiple transactions and perform bulk actions (delete, change category)**,
+So that **I can efficiently manage many transactions at once**.
+
+#### Acceptance Criteria
+
+**Given** I am viewing the transaction list
+**When** I enable bulk selection mode
+**Then** I see checkboxes next to each transaction
+
+**Given** I am in bulk selection mode
+**When** I check multiple transaction checkboxes
+**Then** I see a bulk actions toolbar with "Delete Selected" and "Change Category"
+
+**Given** I have selected 10 transactions
+**When** I click "Delete Selected"
+**Then** I see a confirmation "Are you sure you want to delete 10 transactions?"
+
+**Given** I confirm bulk delete
+**When** the deletion completes
+**Then** all selected transactions are deleted and I see "10 transactions deleted successfully"
+
+**Given** I have selected transactions
+**When** I click "Change Category" and select a new category
+**Then** all selected transactions are updated with the new category
+
+**Given** I select transactions of different types (income and expense)
+**When** I click "Change Category"
+**Then** I see "Cannot change category for transactions of mixed types. Please select transactions of the same type."
+
+**Given** I select all transactions on a page
+**When** I click "Select All" checkbox in the header
+**Then** all visible transactions are selected
+
+#### Technical Requirements
+- Bulk delete: single API call with array of transaction IDs
+- Bulk update: transaction validation (same type for category change)
+- Maximum bulk operation size: 100 transactions at once
+- Optimistic UI updates with rollback on error
+- Progress indicator for large bulk operations
+- Audit log for bulk operations
+- Permissions check: user owns all selected transactions
+
+#### API Endpoint
+```
+DELETE /api/v1/transactions/bulk
+Headers:
+  Authorization: Bearer {accessToken}
+
+Request Body:
+{
+  "transactionIds": ["uuid1", "uuid2", "uuid3"]
+}
+
+Response: 200 OK
+{
+  "deletedCount": 3,
+  "message": "3 transactions deleted successfully"
+}
+
+PATCH /api/v1/transactions/bulk
+Request Body:
+{
+  "transactionIds": ["uuid1", "uuid2"],
+  "categoryId": "new-category-uuid"
+}
+
+Response: 200 OK
+{
+  "updatedCount": 2,
+  "message": "2 transactions updated successfully"
+}
+```
+
+---
+
+## Story Summary
+
+| Story ID | Title | Priority | Story Points | Dependencies |
+|----------|-------|----------|--------------|--------------|
+| TXN-001 | Create Transaction | Must Have | 5 | TXN-007 |
+| TXN-002 | View Transaction List | Must Have | 3 | TXN-001 |
+| TXN-003 | Edit Transaction | Must Have | 3 | TXN-001, TXN-002 |
+| TXN-004 | Delete Transaction | Must Have | 2 | TXN-002 |
+| TXN-005 | Filter Transactions | Must Have | 5 | TXN-002 |
+| TXN-006 | Search Transactions | Should Have | 3 | TXN-002 |
+| TXN-007 | Transaction Categories | Must Have | 3 | None |
+| TXN-008 | Pagination and Sorting | Must Have | 2 | TXN-002 |
+| TXN-009 | Summary and Statistics | Should Have | 3 | TXN-002 |
+| TXN-010 | Bulk Operations | Could Have | 5 | TXN-002 |
+
+**Total Story Points:** 34 (MVP Must-Have: 23, Should-Have: 6, Could-Have: 5)
+
+---
+
+## MoSCoW Prioritization
+
+### Must Have (MVP Critical)
+- TXN-001: Create Transaction
+- TXN-002: View Transaction List
+- TXN-003: Edit Transaction
+- TXN-004: Delete Transaction
+- TXN-005: Filter Transactions
+- TXN-007: Transaction Categories Management
+- TXN-008: Pagination and Sorting
+
+### Should Have (Important for Usability)
+- TXN-006: Search Transactions
+- TXN-009: Transaction Summary and Statistics
+
+### Could Have (Post-MVP)
+- TXN-010: Bulk Operations
+- Transaction attachments (receipts)
+- Recurring transactions
+- Transaction tags
+- Advanced analytics
+
+### Won't Have (Not in Scope)
+- Bank account integration / auto-import
+- OCR receipt scanning
+- Multi-currency support
+- Split transactions
+
+---
+
+## Business Rules
+
+### Transaction Validation
+- Amount must be greater than 0
+- Amount maximum: 10,000,000
+- Date cannot be more than 1 year in the past
+- Date can be in the future (with warning)
+- Description maximum: 500 characters
+- Notes maximum: 1000 characters
+- Category must match transaction type
+
+### Data Integrity
+- User can only see/edit/delete their own transactions
+- Deleting a transaction updates related budget calculations
+- Changing transaction amount/category updates budget progress
+- Transaction type cannot be changed if transaction is linked to budget
+- Soft delete option for audit trail (configurable)
+
+### Performance
+- Default page size: 20 transactions
+- Maximum page size: 100 transactions
+- Database indexes on: user_id, date, category_id, type
+- Full-text search index on description field
+- Cache category list (rarely changes)
+
+---
+
+## Database Schema
+
+### transactions table
+```sql
+CREATE TABLE transactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount DECIMAL(12,2) NOT NULL CHECK (amount > 0),
+  type VARCHAR(20) NOT NULL CHECK (type IN ('INCOME', 'EXPENSE')),
+  category_id UUID NOT NULL REFERENCES categories(id),
+  date DATE NOT NULL,
+  description VARCHAR(500),
+  notes VARCHAR(1000),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_transactions_user_id ON transactions(user_id);
+CREATE INDEX idx_transactions_date ON transactions(date);
+CREATE INDEX idx_transactions_category_id ON transactions(category_id);
+CREATE INDEX idx_transactions_type ON transactions(type);
+CREATE INDEX idx_transactions_user_date ON transactions(user_id, date DESC);
+
+-- Full-text search index
+CREATE INDEX idx_transactions_description ON transactions USING gin(to_tsvector('english', description));
+```
+
+### categories table
+```sql
+CREATE TABLE categories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(100) NOT NULL,
+  type VARCHAR(20) NOT NULL CHECK (type IN ('INCOME', 'EXPENSE')),
+  icon VARCHAR(50),
+  color VARCHAR(7),
+  display_order INT DEFAULT 0,
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_categories_type ON categories(type);
+
+-- Seed data
+INSERT INTO categories (name, type, icon, color, display_order) VALUES
+('Salary', 'INCOME', 'payments', '#4CAF50', 1),
+('Freelance', 'INCOME', 'work', '#8BC34A', 2),
+('Investments', 'INCOME', 'trending_up', '#66BB6A', 3),
+('Gifts', 'INCOME', 'card_giftcard', '#81C784', 4),
+('Refunds', 'INCOME', 'receipt', '#9CCC65', 5),
+('Other Income', 'INCOME', 'attach_money', '#AED581', 6),
+('Food & Dining', 'EXPENSE', 'restaurant', '#F44336', 1),
+('Transportation', 'EXPENSE', 'directions_car', '#E91E63', 2),
+('Housing', 'EXPENSE', 'home', '#9C27B0', 3),
+('Utilities', 'EXPENSE', 'bolt', '#673AB7', 4),
+('Entertainment', 'EXPENSE', 'movie', '#3F51B5', 5),
+('Healthcare', 'EXPENSE', 'local_hospital', '#2196F3', 6),
+('Shopping', 'EXPENSE', 'shopping_bag', '#03A9F4', 7),
+('Education', 'EXPENSE', 'school', '#00BCD4', 8),
+('Travel', 'EXPENSE', 'flight', '#009688', 9),
+('Personal Care', 'EXPENSE', 'spa', '#4CAF50', 10),
+('Subscriptions', 'EXPENSE', 'subscriptions', '#8BC34A', 11),
+('Other', 'EXPENSE', 'more_horiz', '#CDDC39', 12);
+```
+
+---
+
+## Testing Requirements
+
+### Unit Tests
+- Transaction amount validation (positive, max value)
+- Transaction type and category compatibility
+- Date validation (past, present, future)
+- Description and notes length validation
+- Filter logic (multiple conditions)
+- Search functionality (case-insensitive, partial match)
+- Pagination calculations
+- Summary calculations (totals, percentages)
+
+### Integration Tests
+- Create transaction with valid/invalid data
+- Retrieve transactions with pagination
+- Update transaction and verify changes
+- Delete transaction and verify removal
+- Filter transactions by multiple criteria
+- Search transactions by description/notes
+- Category assignment and retrieval
+- Budget recalculation after transaction changes
+
+### E2E Tests (Cypress)
+- User can create a new transaction
+- User can view list of transactions with pagination
+- User can edit an existing transaction
+- User can delete a transaction with confirmation
+- User can filter transactions by date and category
+- User can search for transactions
+- User can see transaction summary and statistics
+- Validation errors display correctly
+
+### Performance Tests
+- Load 1000+ transactions with acceptable response time (<500ms)
+- Pagination with large datasets
+- Filter and search performance with indexes
+- Summary calculation performance
+
+---
+
+## Definition of Done
+
+Each story is considered complete when:
+
+1. **Code Complete**
+   - Backend API endpoints implemented with validation
+   - Frontend forms and list views implemented
+   - All CRUD operations functional
+
+2. **Tests Pass**
+   - Unit tests: >80% coverage
+   - Integration tests: all happy and sad paths
+   - E2E tests: critical user flows
+
+3. **Validation**
+   - All business rules enforced
+   - Error messages are clear and helpful
+   - Edge cases handled gracefully
+
+4. **UI/UX**
+   - Forms are intuitive and accessible
+   - Loading states and error states implemented
+   - Responsive design works on mobile and desktop
+
+5. **Documentation**
+   - API endpoints documented in OpenAPI/Swagger
+   - Frontend component documentation
+   - Database schema documented
+
+6. **Code Review**
+   - PR approved by at least one team member
+   - No critical issues from static analysis
+   - Follows coding standards
+
+7. **Acceptance Criteria Met**
+   - All Given/When/Then scenarios pass
+   - Product Owner accepts the story
+
+---
+
+## Sprint Planning Recommendation
+
+### Sprint 1 (Foundation - 11 points)
+- TXN-007: Transaction Categories Management (3)
+- TXN-001: Create Transaction (5)
+- TXN-002: View Transaction List (3)
+
+### Sprint 2 (CRUD Completion - 10 points)
+- TXN-003: Edit Transaction (3)
+- TXN-004: Delete Transaction (2)
+- TXN-005: Filter Transactions (5)
+
+### Sprint 3 (Enhanced Features - 8 points)
+- TXN-008: Pagination and Sorting (2)
+- TXN-006: Search Transactions (3)
+- TXN-009: Summary and Statistics (3)
+
+### Sprint 4 (Optional Enhancements - 5 points)
+- TXN-010: Bulk Operations (5)
+
+---
+
+## Notes for Development Team
+
+1. **Environment Variables Required:**
+   - `DEFAULT_PAGE_SIZE` - Default pagination size (20)
+   - `MAX_PAGE_SIZE` - Maximum pagination size (100)
+   - `MAX_TRANSACTION_AMOUNT` - Maximum transaction amount (10000000)
+
+2. **Backend Libraries:**
+   - Spring Data JPA (database access)
+   - Bean Validation (JSR-380)
+   - MapStruct (entity-DTO mapping)
+   - QueryDSL (dynamic filtering)
+
+3. **Frontend Libraries:**
+   - React Hook Form (form validation)
+   - Material-UI Data Grid (transaction list)
+   - Date-fns (date formatting and manipulation)
+   - React Query (API state management and caching)
+
+4. **Performance Considerations:**
+   - Index all foreign keys and frequently filtered columns
+   - Use pagination for all list endpoints
+   - Implement database-level filtering (don't filter in memory)
+   - Cache category list on frontend
+   - Consider Redis for summary calculations cache
+
+5. **Security:**
+   - Always filter transactions by authenticated user ID
+   - Validate user ownership before update/delete
+   - Sanitize search input to prevent SQL injection
+   - Rate limit transaction creation (prevent spam)
+
+6. **Accessibility:**
+   - Form labels and ARIA attributes
+   - Keyboard navigation for transaction list
+   - Screen reader announcements for success/error messages
+   - Focus management for modals
+
+---
+
+## API Response Examples
+
+### Error Responses
+
+```json
+// 400 Bad Request - Validation Error
+{
+  "status": 400,
+  "message": "Validation failed",
+  "errors": [
+    {
+      "field": "amount",
+      "message": "Amount must be greater than 0"
+    },
+    {
+      "field": "categoryId",
+      "message": "Category is required"
+    }
+  ],
+  "timestamp": "2026-01-23T10:30:00Z"
+}
+
+// 403 Forbidden - Not Owner
+{
+  "status": 403,
+  "message": "You do not have permission to access this transaction",
+  "timestamp": "2026-01-23T10:30:00Z"
+}
+
+// 404 Not Found
+{
+  "status": 404,
+  "message": "Transaction not found",
+  "timestamp": "2026-01-23T10:30:00Z"
+}
+```
+
+---
+
+## References
+
+- Personal Finance App PRD
+- Epic 1: Authentication User Stories
+- Database Design Documentation
+- API Design Guidelines (RESTful best practices)
+- Material-UI Data Grid Documentation

--- a/docs/test-coverage/epic-2-transactions.md
+++ b/docs/test-coverage/epic-2-transactions.md
@@ -1,0 +1,291 @@
+# Test Coverage: Epic 2 - Transactions
+
+## Overview
+
+This document outlines the test coverage for Epic 2 (Transactions) of the Personal Finance Web App. Tests cover user stories #3-#12 including transaction CRUD operations, filtering, pagination, and summary statistics.
+
+## Test Pyramid Distribution
+
+| Layer | Target | Current | Files |
+|-------|--------|---------|-------|
+| Unit Tests | 70% | - | 6 files |
+| Integration Tests | 20% | - | 1 file |
+| E2E Tests | 10% | - | Planned |
+
+## Backend Tests
+
+### Controller Tests
+
+#### TransactionControllerTest.java
+
+Location: `backend/src/test/java/com/pfwa/controller/TransactionControllerTest.java`
+
+| Test Class | Test Cases | Coverage |
+|------------|------------|----------|
+| CreateTransactionTests | 12 tests | Create transaction scenarios |
+| GetTransactionsTests | 9 tests | List and filter transactions |
+| GetTransactionByIdTests | 3 tests | Get single transaction |
+| UpdateTransactionTests | 4 tests | Update transaction scenarios |
+| DeleteTransactionTests | 3 tests | Delete transaction scenarios |
+| GetTransactionSummaryTests | 2 tests | Summary statistics |
+
+**Test Scenarios:**
+- Create transaction with valid data (201 Created)
+- Validation errors (missing amount, zero amount, negative amount, exceeds max)
+- Missing required fields (type, categoryId, date)
+- Description/notes exceeding max length
+- Category not found (404)
+- Category type mismatch with transaction type
+- Null optional fields
+- Income and expense transaction types
+
+#### CategoryControllerTest.java
+
+Location: `backend/src/test/java/com/pfwa/controller/CategoryControllerTest.java`
+
+| Test Class | Test Cases | Coverage |
+|------------|------------|----------|
+| GetCategoriesTests | 9 tests | Category listing |
+
+**Test Scenarios:**
+- Get all categories grouped by type
+- Filter by INCOME type
+- Filter by EXPENSE type
+- Empty category lists
+- Category response details
+- Cache-Control header
+- Invalid type parameter
+- Display order preservation
+
+### Service Tests
+
+#### TransactionServiceTest.java
+
+Location: `backend/src/test/java/com/pfwa/service/TransactionServiceTest.java`
+
+| Test Class | Test Cases | Coverage |
+|------------|------------|----------|
+| CreateTransactionTests | 4 tests | Business logic for creation |
+| GetTransactionTests | 3 tests | Single transaction retrieval |
+| GetTransactionsTests | 3 tests | List with pagination |
+| UpdateTransactionTests | 4 tests | Update logic |
+| DeleteTransactionTests | 3 tests | Delete logic |
+| GetTransactionSummaryTests | 3 tests | Summary calculations |
+
+**Test Scenarios:**
+- Create with valid data
+- Category type mismatch exception
+- Transaction not found exception
+- User isolation (access control)
+- Summary calculation accuracy
+- Default date range handling
+
+#### CategoryServiceTest.java
+
+Location: `backend/src/test/java/com/pfwa/service/CategoryServiceTest.java`
+
+| Test Class | Test Cases | Coverage |
+|------------|------------|----------|
+| GetAllCategoriesTests | 4 tests | All categories |
+| GetCategoriesByTypeTests | 4 tests | Filtered by type |
+| GetCategoryByIdTests | 3 tests | Single category |
+| ValidateCategoryForTypeTests | 3 tests | Type validation |
+| CategoryResponseMappingTests | 2 tests | DTO mapping |
+
+### Integration Tests
+
+#### TransactionControllerIntegrationTest.java
+
+Location: `backend/src/test/java/com/pfwa/controller/TransactionControllerIntegrationTest.java`
+
+Uses TestContainers for PostgreSQL database testing.
+
+| Test Class | Test Cases | Coverage |
+|------------|------------|----------|
+| CreateTransactionIntegrationTests | 4 tests | End-to-end creation |
+| GetTransactionsIntegrationTests | 10 tests | Full filtering |
+| GetTransactionByIdIntegrationTests | 3 tests | Single transaction |
+| UpdateTransactionIntegrationTests | 3 tests | Update flow |
+| DeleteTransactionIntegrationTests | 3 tests | Delete flow |
+| GetSummaryIntegrationTests | 2 tests | Summary endpoint |
+
+**Key Integration Scenarios:**
+- Full request/response cycle with database
+- User authentication via JWT
+- User isolation (cannot access other users' transactions)
+- Filter combinations (date, type, category, amount, search)
+- Pagination and sorting
+- Database state verification
+
+## Frontend Tests
+
+### Component Tests
+
+#### TransactionList.test.tsx
+
+Location: `frontend/src/components/transactions/TransactionList.test.tsx`
+
+| Test Suite | Test Cases | Coverage |
+|------------|------------|----------|
+| Rendering | 7 tests | Table structure, data display |
+| Empty State | 2 tests | No data handling |
+| Loading State | 2 tests | Skeleton loading |
+| Sorting | 4 tests | Sort interactions |
+| Pagination | 5 tests | Page navigation |
+| Actions | 4 tests | Edit/Delete buttons |
+| Row Expansion | 4 tests | Expandable details |
+| Description Truncation | 3 tests | Text overflow |
+| Visual Indicators | 2 tests | Color coding |
+| Accessibility | 4 tests | A11y compliance |
+
+#### TransactionForm.test.tsx
+
+Location: `frontend/src/components/transactions/TransactionForm.test.tsx`
+
+| Test Suite | Test Cases | Coverage |
+|------------|------------|----------|
+| Rendering - Create Mode | 5 tests | Form fields |
+| Rendering - Edit Mode | 2 tests | Pre-filled data |
+| Validation | 8 tests | Input validation |
+| Form Submission | 3 tests | Submit handling |
+| Type Switching | 2 tests | INCOME/EXPENSE toggle |
+| Loading State | 3 tests | Disabled during submit |
+| Error Display | 2 tests | Error messages |
+| Character Counters | 3 tests | Length limits |
+| Edit Mode - No Changes | 2 tests | Dirty tracking |
+
+#### TransactionFilter.test.tsx
+
+Location: `frontend/src/components/transactions/TransactionFilter.test.tsx`
+
+| Test Suite | Test Cases | Coverage |
+|------------|------------|----------|
+| Rendering | 5 tests | Filter panel |
+| Active Filter Count | 3 tests | Badge display |
+| Date Range Filter | 3 tests | Date selection |
+| Type Filter | 3 tests | Type dropdown |
+| Category Filter | 3 tests | Category multi-select |
+| Amount Filter | 3 tests | Amount inputs |
+| Clear Filters | 3 tests | Reset functionality |
+| Collapse/Expand | 2 tests | Toggle behavior |
+| Preserved Filter Values | 1 test | State persistence |
+
+### Page Tests
+
+#### TransactionsPage.test.tsx
+
+Location: `frontend/src/pages/transactions/TransactionsPage.test.tsx`
+
+| Test Suite | Test Cases | Coverage |
+|------------|------------|----------|
+| Initial Rendering | 4 tests | Page structure |
+| Summary Display | 1 test | Summary cards |
+| Empty State | 1 test | No transactions |
+| Error Handling | 1 test | API errors |
+| Navigation | 3 tests | Page routing |
+| Delete Transaction | 4 tests | Delete flow |
+| Filtering | 2 tests | URL parameters |
+| Pagination | 1 test | Page params |
+| Search | 1 test | Search param |
+| User Menu | 2 tests | Account menu |
+
+### API Tests
+
+#### transactionApi.test.ts
+
+Location: `frontend/src/api/transactionApi.test.ts`
+
+| Test Suite | Test Cases | Coverage |
+|------------|------------|----------|
+| getTransactions | 4 tests | List endpoint |
+| getTransaction | 2 tests | Single endpoint |
+| createTransaction | 3 tests | Create endpoint |
+| updateTransaction | 2 tests | Update endpoint |
+| deleteTransaction | 2 tests | Delete endpoint |
+| getSummary | 4 tests | Summary endpoint |
+| Query Parameter Building | 5 tests | URL construction |
+
+## User Story Coverage
+
+| Issue | User Story | Backend Tests | Frontend Tests |
+|-------|------------|---------------|----------------|
+| #3 | Add manual transaction | Create tests | TransactionForm tests |
+| #4 | View transaction list | GetTransactions tests | TransactionList tests |
+| #5 | Edit transaction | Update tests | TransactionForm tests |
+| #6 | Delete transaction | Delete tests | Delete dialog tests |
+| #7 | Categorize transactions | Category tests | CategorySelect tests |
+| #8 | Filter by date | DateRange filter tests | TransactionFilter tests |
+| #9 | Filter by type | Type filter tests | TransactionFilter tests |
+| #10 | Filter by category | Category filter tests | TransactionFilter tests |
+| #11 | Search transactions | Search filter tests | TransactionSearch tests |
+| #12 | View summary | Summary tests | TransactionSummary tests |
+
+## Test Patterns Used
+
+### Backend
+
+- **AAA Pattern**: Arrange-Act-Assert structure
+- **MockMvc**: Controller testing without full context
+- **Mockito**: Service and repository mocking
+- **TestContainers**: PostgreSQL for integration tests
+- **Nested Test Classes**: Organized by endpoint/method
+- **@DisplayName**: Clear test descriptions
+
+### Frontend
+
+- **React Testing Library**: Component testing
+- **Vitest**: Test runner and assertions
+- **userEvent**: User interaction simulation
+- **Mock Service Worker patterns**: API mocking
+- **Custom render functions**: Provider wrapping
+- **waitFor**: Async operation handling
+
+## Running Tests
+
+### Backend
+
+```bash
+# Run all tests
+./gradlew test
+
+# Run specific test class
+./gradlew test --tests TransactionControllerTest
+
+# Run with coverage
+./gradlew test jacocoTestReport
+```
+
+### Frontend
+
+```bash
+# Run all tests
+npm test
+
+# Run specific test file
+npm test -- TransactionList.test.tsx
+
+# Run with coverage
+npm test -- --coverage
+```
+
+## Coverage Targets
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Line Coverage | > 80% | Services, controllers |
+| Branch Coverage | > 75% | Conditional logic |
+| Method Coverage | > 85% | Public methods |
+
+## Excluded from Coverage
+
+- Entity getters/setters (JPA entities)
+- Configuration classes
+- Exception classes (simple wrappers)
+- Main application class
+
+## Future Improvements
+
+1. **E2E Tests**: Add Cypress tests for critical flows
+2. **Performance Tests**: Load testing for list endpoints
+3. **Security Tests**: Penetration testing for auth
+4. **Mutation Testing**: Verify test quality with PIT

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,9 @@ import {
   VerifyEmailPage,
   DashboardPage,
   SettingsPage,
+  TransactionsPage,
+  CreateTransactionPage,
+  EditTransactionPage,
 } from '@/pages';
 import { ROUTES } from '@/constants';
 
@@ -104,6 +107,32 @@ const AppRoutes: React.FC = () => {
         element={
           <ProtectedRoute>
             <SettingsPage />
+          </ProtectedRoute>
+        }
+      />
+
+      {/* Transaction routes */}
+      <Route
+        path={ROUTES.TRANSACTIONS}
+        element={
+          <ProtectedRoute>
+            <TransactionsPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path={ROUTES.TRANSACTIONS_NEW}
+        element={
+          <ProtectedRoute>
+            <CreateTransactionPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path={ROUTES.TRANSACTIONS_EDIT}
+        element={
+          <ProtectedRoute>
+            <EditTransactionPage />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/api/categoryApi.ts
+++ b/frontend/src/api/categoryApi.ts
@@ -1,0 +1,19 @@
+import api from './axiosConfig';
+import type { CategoriesResponse, TransactionType } from '@/types';
+
+/**
+ * Category API service
+ */
+export const categoryApi = {
+  /**
+   * Get all categories grouped by type
+   * Optionally filter by transaction type
+   */
+  getCategories: async (type?: TransactionType): Promise<CategoriesResponse> => {
+    const url = type ? `/categories?type=${type}` : '/categories';
+    const response = await api.get<CategoriesResponse>(url);
+    return response.data;
+  },
+};
+
+export default categoryApi;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,2 +1,4 @@
 export { default as api, getErrorMessage, getFieldErrors } from './axiosConfig';
 export { authApi } from './authApi';
+export { transactionApi } from './transactionApi';
+export { categoryApi } from './categoryApi';

--- a/frontend/src/api/transactionApi.test.ts
+++ b/frontend/src/api/transactionApi.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+import { transactionApi } from './transactionApi';
+import type {
+  Transaction,
+  TransactionListResponse,
+  CreateTransactionRequest,
+  UpdateTransactionRequest,
+  TransactionFilter,
+  TransactionSummaryResponse,
+} from '@/types';
+
+// Mock axios
+vi.mock('./axiosConfig', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('transactionApi', () => {
+  let mockApi: {
+    get: ReturnType<typeof vi.fn>;
+    post: ReturnType<typeof vi.fn>;
+    put: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const api = await import('./axiosConfig');
+    mockApi = api.default as typeof mockApi;
+  });
+
+  const mockTransaction: Transaction = {
+    id: 'tx-1',
+    amount: 150.0,
+    type: 'EXPENSE',
+    category: {
+      id: 'cat-1',
+      name: 'Food & Dining',
+      type: 'EXPENSE',
+      icon: 'restaurant',
+      color: '#F44336',
+    },
+    date: '2026-01-20',
+    description: 'Grocery shopping',
+    notes: 'Weekly groceries',
+    createdAt: '2026-01-20T14:30:00Z',
+    updatedAt: '2026-01-20T14:30:00Z',
+  };
+
+  const mockTransactionListResponse: TransactionListResponse = {
+    content: [mockTransaction],
+    page: 0,
+    size: 20,
+    totalElements: 1,
+    totalPages: 1,
+    first: true,
+    last: true,
+    summary: {
+      totalIncome: 0,
+      totalExpenses: 150.0,
+      netBalance: -150.0,
+    },
+  };
+
+  const mockSummaryResponse: TransactionSummaryResponse = {
+    period: {
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+    },
+    totals: {
+      income: 5000.0,
+      expenses: 3250.5,
+      net: 1749.5,
+      transactionCount: 47,
+    },
+    categoryBreakdown: {
+      income: [],
+      expense: [],
+    },
+  };
+
+  describe('getTransactions', () => {
+    it('should fetch transactions without filters', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      const result = await transactionApi.getTransactions();
+
+      expect(mockApi.get).toHaveBeenCalledWith('/transactions');
+      expect(result).toEqual(mockTransactionListResponse);
+    });
+
+    it('should fetch transactions with all filters', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      const filter: TransactionFilter = {
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        type: 'EXPENSE',
+        categoryIds: ['cat-1', 'cat-2'],
+        minAmount: 50,
+        maxAmount: 500,
+        search: 'grocery',
+        page: 0,
+        size: 20,
+        sort: 'date,desc',
+      };
+
+      const result = await transactionApi.getTransactions(filter);
+
+      expect(mockApi.get).toHaveBeenCalledWith(
+        expect.stringContaining('/transactions?')
+      );
+      const callUrl = mockApi.get.mock.calls[0][0];
+      expect(callUrl).toContain('startDate=2026-01-01');
+      expect(callUrl).toContain('endDate=2026-01-31');
+      expect(callUrl).toContain('type=EXPENSE');
+      expect(callUrl).toContain('categoryIds=cat-1%2Ccat-2');
+      expect(callUrl).toContain('minAmount=50');
+      expect(callUrl).toContain('maxAmount=500');
+      expect(callUrl).toContain('search=grocery');
+      expect(callUrl).toContain('page=0');
+      expect(callUrl).toContain('size=20');
+      expect(callUrl).toContain('sort=date%2Cdesc');
+      expect(result).toEqual(mockTransactionListResponse);
+    });
+
+    it('should handle empty filter values', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      const filter: TransactionFilter = {
+        startDate: undefined,
+        type: undefined,
+        page: 0,
+      };
+
+      await transactionApi.getTransactions(filter);
+
+      const callUrl = mockApi.get.mock.calls[0][0];
+      expect(callUrl).not.toContain('startDate');
+      expect(callUrl).not.toContain('type');
+      expect(callUrl).toContain('page=0');
+    });
+
+    it('should handle API errors', async () => {
+      const error = new Error('Network error');
+      mockApi.get.mockRejectedValue(error);
+
+      await expect(transactionApi.getTransactions()).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('getTransaction', () => {
+    it('should fetch a single transaction by ID', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransaction });
+
+      const result = await transactionApi.getTransaction('tx-1');
+
+      expect(mockApi.get).toHaveBeenCalledWith('/transactions/tx-1');
+      expect(result).toEqual(mockTransaction);
+    });
+
+    it('should handle not found error', async () => {
+      const error = { response: { status: 404, data: { message: 'Transaction not found' } } };
+      mockApi.get.mockRejectedValue(error);
+
+      await expect(transactionApi.getTransaction('invalid-id')).rejects.toEqual(error);
+    });
+  });
+
+  describe('createTransaction', () => {
+    it('should create a new transaction', async () => {
+      mockApi.post.mockResolvedValue({ data: mockTransaction });
+
+      const request: CreateTransactionRequest = {
+        amount: 150.0,
+        type: 'EXPENSE',
+        categoryId: 'cat-1',
+        date: '2026-01-20',
+        description: 'Grocery shopping',
+        notes: 'Weekly groceries',
+      };
+
+      const result = await transactionApi.createTransaction(request);
+
+      expect(mockApi.post).toHaveBeenCalledWith('/transactions', request);
+      expect(result).toEqual(mockTransaction);
+    });
+
+    it('should create transaction with null optional fields', async () => {
+      mockApi.post.mockResolvedValue({ data: mockTransaction });
+
+      const request: CreateTransactionRequest = {
+        amount: 100.0,
+        type: 'EXPENSE',
+        categoryId: 'cat-1',
+        date: '2026-01-20',
+        description: null,
+        notes: null,
+      };
+
+      await transactionApi.createTransaction(request);
+
+      expect(mockApi.post).toHaveBeenCalledWith('/transactions', request);
+    });
+
+    it('should handle validation errors', async () => {
+      const error = {
+        response: {
+          status: 400,
+          data: {
+            error: 'VALIDATION_ERROR',
+            fieldErrors: [{ field: 'amount', message: 'Amount must be greater than 0' }],
+          },
+        },
+      };
+      mockApi.post.mockRejectedValue(error);
+
+      await expect(
+        transactionApi.createTransaction({
+          amount: -100,
+          type: 'EXPENSE',
+          categoryId: 'cat-1',
+          date: '2026-01-20',
+        })
+      ).rejects.toEqual(error);
+    });
+  });
+
+  describe('updateTransaction', () => {
+    it('should update an existing transaction', async () => {
+      const updatedTransaction = { ...mockTransaction, amount: 200.0 };
+      mockApi.put.mockResolvedValue({ data: updatedTransaction });
+
+      const request: UpdateTransactionRequest = {
+        amount: 200.0,
+        type: 'EXPENSE',
+        categoryId: 'cat-1',
+        date: '2026-01-20',
+        description: 'Updated description',
+        notes: null,
+      };
+
+      const result = await transactionApi.updateTransaction('tx-1', request);
+
+      expect(mockApi.put).toHaveBeenCalledWith('/transactions/tx-1', request);
+      expect(result.amount).toBe(200.0);
+    });
+
+    it('should handle not found on update', async () => {
+      const error = { response: { status: 404, data: { message: 'Transaction not found' } } };
+      mockApi.put.mockRejectedValue(error);
+
+      await expect(
+        transactionApi.updateTransaction('invalid-id', {
+          amount: 100,
+          type: 'EXPENSE',
+          categoryId: 'cat-1',
+          date: '2026-01-20',
+        })
+      ).rejects.toEqual(error);
+    });
+  });
+
+  describe('deleteTransaction', () => {
+    it('should delete a transaction', async () => {
+      mockApi.delete.mockResolvedValue({ data: null });
+
+      await transactionApi.deleteTransaction('tx-1');
+
+      expect(mockApi.delete).toHaveBeenCalledWith('/transactions/tx-1');
+    });
+
+    it('should handle not found on delete', async () => {
+      const error = { response: { status: 404, data: { message: 'Transaction not found' } } };
+      mockApi.delete.mockRejectedValue(error);
+
+      await expect(transactionApi.deleteTransaction('invalid-id')).rejects.toEqual(error);
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should fetch transaction summary without dates', async () => {
+      mockApi.get.mockResolvedValue({ data: mockSummaryResponse });
+
+      const result = await transactionApi.getSummary();
+
+      expect(mockApi.get).toHaveBeenCalledWith('/transactions/summary');
+      expect(result).toEqual(mockSummaryResponse);
+    });
+
+    it('should fetch transaction summary with date range', async () => {
+      mockApi.get.mockResolvedValue({ data: mockSummaryResponse });
+
+      const result = await transactionApi.getSummary('2026-01-01', '2026-01-31');
+
+      expect(mockApi.get).toHaveBeenCalledWith(
+        '/transactions/summary?startDate=2026-01-01&endDate=2026-01-31'
+      );
+      expect(result).toEqual(mockSummaryResponse);
+    });
+
+    it('should fetch summary with only start date', async () => {
+      mockApi.get.mockResolvedValue({ data: mockSummaryResponse });
+
+      await transactionApi.getSummary('2026-01-01');
+
+      expect(mockApi.get).toHaveBeenCalledWith('/transactions/summary?startDate=2026-01-01');
+    });
+
+    it('should fetch summary with only end date', async () => {
+      mockApi.get.mockResolvedValue({ data: mockSummaryResponse });
+
+      await transactionApi.getSummary(undefined, '2026-01-31');
+
+      expect(mockApi.get).toHaveBeenCalledWith('/transactions/summary?endDate=2026-01-31');
+    });
+  });
+
+  describe('Query Parameter Building', () => {
+    it('should not include undefined values in query string', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      await transactionApi.getTransactions({
+        type: 'EXPENSE',
+        startDate: undefined,
+        endDate: undefined,
+        categoryIds: undefined,
+      });
+
+      const callUrl = mockApi.get.mock.calls[0][0];
+      expect(callUrl).toBe('/transactions?type=EXPENSE');
+    });
+
+    it('should handle empty categoryIds array', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      await transactionApi.getTransactions({
+        categoryIds: [],
+      });
+
+      const callUrl = mockApi.get.mock.calls[0][0];
+      expect(callUrl).not.toContain('categoryIds');
+    });
+
+    it('should handle null amount values', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      await transactionApi.getTransactions({
+        minAmount: null as unknown as undefined,
+        maxAmount: undefined,
+      });
+
+      const callUrl = mockApi.get.mock.calls[0][0];
+      expect(callUrl).not.toContain('minAmount');
+      expect(callUrl).not.toContain('maxAmount');
+    });
+
+    it('should handle zero amount values', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      await transactionApi.getTransactions({
+        minAmount: 0,
+        maxAmount: 0,
+      });
+
+      const callUrl = mockApi.get.mock.calls[0][0];
+      expect(callUrl).toContain('minAmount=0');
+      expect(callUrl).toContain('maxAmount=0');
+    });
+
+    it('should encode special characters in search', async () => {
+      mockApi.get.mockResolvedValue({ data: mockTransactionListResponse });
+
+      await transactionApi.getTransactions({
+        search: 'coffee & tea',
+      });
+
+      const callUrl = mockApi.get.mock.calls[0][0];
+      expect(callUrl).toContain('search=coffee+%26+tea');
+    });
+  });
+});

--- a/frontend/src/api/transactionApi.ts
+++ b/frontend/src/api/transactionApi.ts
@@ -1,0 +1,115 @@
+import api from './axiosConfig';
+import type {
+  Transaction,
+  CreateTransactionRequest,
+  UpdateTransactionRequest,
+  TransactionListResponse,
+  TransactionFilter,
+  TransactionSummaryResponse,
+} from '@/types';
+
+/**
+ * Build query string from transaction filter parameters
+ */
+const buildQueryParams = (filter: TransactionFilter): URLSearchParams => {
+  const params = new URLSearchParams();
+
+  if (filter.startDate) {
+    params.append('startDate', filter.startDate);
+  }
+  if (filter.endDate) {
+    params.append('endDate', filter.endDate);
+  }
+  if (filter.type) {
+    params.append('type', filter.type);
+  }
+  if (filter.categoryIds && filter.categoryIds.length > 0) {
+    params.append('categoryIds', filter.categoryIds.join(','));
+  }
+  if (filter.minAmount !== undefined && filter.minAmount !== null) {
+    params.append('minAmount', filter.minAmount.toString());
+  }
+  if (filter.maxAmount !== undefined && filter.maxAmount !== null) {
+    params.append('maxAmount', filter.maxAmount.toString());
+  }
+  if (filter.search) {
+    params.append('search', filter.search);
+  }
+  if (filter.page !== undefined) {
+    params.append('page', filter.page.toString());
+  }
+  if (filter.size !== undefined) {
+    params.append('size', filter.size.toString());
+  }
+  if (filter.sort) {
+    params.append('sort', filter.sort);
+  }
+
+  return params;
+};
+
+/**
+ * Transaction API service
+ */
+export const transactionApi = {
+  /**
+   * Get paginated list of transactions with optional filtering
+   */
+  getTransactions: async (filter: TransactionFilter = {}): Promise<TransactionListResponse> => {
+    const params = buildQueryParams(filter);
+    const queryString = params.toString();
+    const url = queryString ? `/transactions?${queryString}` : '/transactions';
+    const response = await api.get<TransactionListResponse>(url);
+    return response.data;
+  },
+
+  /**
+   * Get a single transaction by ID
+   */
+  getTransaction: async (id: string): Promise<Transaction> => {
+    const response = await api.get<Transaction>(`/transactions/${id}`);
+    return response.data;
+  },
+
+  /**
+   * Create a new transaction
+   */
+  createTransaction: async (data: CreateTransactionRequest): Promise<Transaction> => {
+    const response = await api.post<Transaction>('/transactions', data);
+    return response.data;
+  },
+
+  /**
+   * Update an existing transaction
+   */
+  updateTransaction: async (id: string, data: UpdateTransactionRequest): Promise<Transaction> => {
+    const response = await api.put<Transaction>(`/transactions/${id}`, data);
+    return response.data;
+  },
+
+  /**
+   * Delete a transaction
+   */
+  deleteTransaction: async (id: string): Promise<void> => {
+    await api.delete(`/transactions/${id}`);
+  },
+
+  /**
+   * Get transaction summary and statistics
+   */
+  getSummary: async (startDate?: string, endDate?: string): Promise<TransactionSummaryResponse> => {
+    const params = new URLSearchParams();
+    if (startDate) {
+      params.append('startDate', startDate);
+    }
+    if (endDate) {
+      params.append('endDate', endDate);
+    }
+    const queryString = params.toString();
+    const url = queryString ? `/transactions/summary?${queryString}` : '/transactions/summary';
+    const response = await api.get<TransactionSummaryResponse>(url);
+    return response.data;
+  },
+};
+
+export default transactionApi;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as ProtectedRoute } from './ProtectedRoute';
 export * from './auth';
 export * from './common';
+export * from './transactions';

--- a/frontend/src/components/transactions/CategorySelect.tsx
+++ b/frontend/src/components/transactions/CategorySelect.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  FormHelperText,
+  ListItemIcon,
+  ListItemText,
+  Box,
+  CircularProgress,
+  SelectProps,
+} from '@mui/material';
+import Icon from '@mui/material/Icon';
+import type { Category, TransactionType, CategoriesResponse } from '@/types';
+import { categoryApi } from '@/api';
+import { getErrorMessage } from '@/api';
+
+interface CategorySelectProps extends Omit<SelectProps, 'onChange'> {
+  transactionType: TransactionType;
+  value: string;
+  onChange: (categoryId: string) => void;
+  error?: boolean;
+  helperText?: string;
+}
+
+/**
+ * CategorySelect - Dropdown for selecting transaction category
+ * Filters categories based on transaction type (INCOME/EXPENSE)
+ */
+const CategorySelect: React.FC<CategorySelectProps> = ({
+  transactionType,
+  value,
+  onChange,
+  error = false,
+  helperText,
+  disabled,
+  ...props
+}) => {
+  const [categories, setCategories] = useState<CategoriesResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  const fetchCategories = useCallback(async () => {
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const data = await categoryApi.getCategories();
+      setCategories(data);
+    } catch (err) {
+      setFetchError(getErrorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  // Get categories for the selected type (memoized to prevent dependency issues)
+  const filteredCategories = useMemo<Category[]>(() => {
+    return categories?.[transactionType === 'INCOME' ? 'income' : 'expense'] || [];
+  }, [categories, transactionType]);
+
+  // Reset value if category doesn't match type
+  useEffect(() => {
+    if (value && categories) {
+      const categoryExists = filteredCategories.some((cat) => cat.id === value);
+      if (!categoryExists) {
+        onChange('');
+      }
+    }
+  }, [transactionType, value, categories, filteredCategories, onChange]);
+
+  const handleChange = (event: { target: { value: unknown } }) => {
+    onChange(event.target.value as string);
+  };
+
+  const displayHelperText = fetchError || helperText;
+
+  return (
+    <FormControl fullWidth error={error || !!fetchError} disabled={disabled || loading}>
+      <InputLabel id="category-select-label">Category</InputLabel>
+      <Select
+        labelId="category-select-label"
+        id="category-select"
+        value={value}
+        label="Category"
+        onChange={handleChange}
+        startAdornment={
+          loading ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', mr: 1 }}>
+              <CircularProgress size={20} />
+            </Box>
+          ) : null
+        }
+        {...props}
+      >
+        {filteredCategories.map((category) => (
+          <MenuItem key={category.id} value={category.id}>
+            <ListItemIcon sx={{ minWidth: 40 }}>
+              <Icon sx={{ color: category.color }}>{category.icon}</Icon>
+            </ListItemIcon>
+            <ListItemText primary={category.name} />
+          </MenuItem>
+        ))}
+        {filteredCategories.length === 0 && !loading && (
+          <MenuItem disabled>
+            <ListItemText primary="No categories available" />
+          </MenuItem>
+        )}
+      </Select>
+      {displayHelperText && <FormHelperText>{displayHelperText}</FormHelperText>}
+    </FormControl>
+  );
+};
+
+export default CategorySelect;

--- a/frontend/src/components/transactions/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/transactions/DeleteConfirmDialog.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  CircularProgress,
+} from '@mui/material';
+import WarningIcon from '@mui/icons-material/Warning';
+import { Box } from '@mui/material';
+
+interface DeleteConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  loading?: boolean;
+  title?: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+/**
+ * DeleteConfirmDialog - Confirmation dialog for deletion
+ * Displays a warning and requires explicit confirmation
+ */
+const DeleteConfirmDialog: React.FC<DeleteConfirmDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  loading = false,
+  title = 'Delete Transaction',
+  message = 'Are you sure you want to delete this transaction? This action cannot be undone.',
+  confirmText = 'Delete',
+  cancelText = 'Cancel',
+}) => {
+  const handleConfirm = () => {
+    if (!loading) {
+      onConfirm();
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={loading ? undefined : onClose}
+      aria-labelledby="delete-dialog-title"
+      aria-describedby="delete-dialog-description"
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle id="delete-dialog-title">
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <WarningIcon color="error" />
+          {title}
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="delete-dialog-description">
+          {message}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={loading} color="inherit">
+          {cancelText}
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          color="error"
+          variant="contained"
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={20} color="inherit" /> : null}
+        >
+          {loading ? 'Deleting...' : confirmText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeleteConfirmDialog;

--- a/frontend/src/components/transactions/TransactionFilter.test.tsx
+++ b/frontend/src/components/transactions/TransactionFilter.test.tsx
@@ -1,0 +1,501 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material';
+import TransactionFilter from './TransactionFilter';
+import type { TransactionFilter as TransactionFilterType } from '@/types';
+
+const theme = createTheme();
+
+// Mock the categoryApi
+vi.mock('@/api', () => ({
+  categoryApi: {
+    getCategories: vi.fn().mockResolvedValue({
+      income: [
+        { id: 'cat-salary', name: 'Salary', type: 'INCOME', icon: 'payments', color: '#4CAF50' },
+        { id: 'cat-freelance', name: 'Freelance', type: 'INCOME', icon: 'work', color: '#8BC34A' },
+      ],
+      expense: [
+        { id: 'cat-food', name: 'Food & Dining', type: 'EXPENSE', icon: 'restaurant', color: '#F44336' },
+        { id: 'cat-transport', name: 'Transportation', type: 'EXPENSE', icon: 'directions_car', color: '#E91E63' },
+      ],
+    }),
+  },
+  getErrorMessage: vi.fn((err) => err?.message || 'An error occurred'),
+}));
+
+const emptyFilter: TransactionFilterType = {};
+
+const defaultProps = {
+  filter: emptyFilter,
+  onFilterChange: vi.fn(),
+  onClear: vi.fn(),
+};
+
+const renderTransactionFilter = (props = {}) => {
+  return render(
+    <ThemeProvider theme={theme}>
+      <TransactionFilter {...defaultProps} {...props} />
+    </ThemeProvider>
+  );
+};
+
+describe('TransactionFilter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render filter header', () => {
+      renderTransactionFilter();
+
+      expect(screen.getByText('Filters')).toBeInTheDocument();
+    });
+
+    it('should be collapsed by default', () => {
+      renderTransactionFilter();
+
+      // Filter content should not be visible
+      expect(screen.queryByLabelText(/date range/i)).not.toBeInTheDocument();
+    });
+
+    it('should expand when clicking header', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter();
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/date range/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show all filter options when expanded', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter();
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/date range/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/type/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/categories/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/min amount/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/max amount/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show Clear Filters button when expanded', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter();
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Active Filter Count', () => {
+    it('should not show badge when no filters are active', () => {
+      renderTransactionFilter({ filter: {} });
+
+      expect(screen.queryByText('0')).not.toBeInTheDocument();
+    });
+
+    it('should show badge with count when filters are active', () => {
+      renderTransactionFilter({
+        filter: {
+          startDate: '2026-01-01',
+          type: 'EXPENSE',
+        },
+      });
+
+      // Should show count of 2 active filters
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('should count category filter as one even with multiple categories', () => {
+      renderTransactionFilter({
+        filter: {
+          categoryIds: ['cat-food', 'cat-transport'],
+        },
+      });
+
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+  });
+
+  describe('Date Range Filter', () => {
+    it('should call onFilterChange when selecting date preset', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({ onFilterChange });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/date range/i)).toBeInTheDocument();
+      });
+
+      // Open date range dropdown
+      await user.click(screen.getByLabelText(/date range/i));
+      await user.click(screen.getByRole('option', { name: /last 7 days/i }));
+
+      expect(onFilterChange).toHaveBeenCalled();
+      const callArgs = onFilterChange.mock.calls[0][0];
+      expect(callArgs.startDate).toBeDefined();
+      expect(callArgs.endDate).toBeDefined();
+    });
+
+    it('should allow custom date range', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({ onFilterChange });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/start date/i)).toBeInTheDocument();
+      });
+
+      const startDateInput = screen.getByLabelText(/start date/i);
+      await user.type(startDateInput, '2026-01-01');
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate: '2026-01-01',
+        })
+      );
+    });
+
+    it('should update end date filter', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({ onFilterChange });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/end date/i)).toBeInTheDocument();
+      });
+
+      const endDateInput = screen.getByLabelText(/end date/i);
+      await user.type(endDateInput, '2026-01-31');
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endDate: '2026-01-31',
+        })
+      );
+    });
+  });
+
+  describe('Type Filter', () => {
+    it('should call onFilterChange when selecting type', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({ onFilterChange });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/type/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText(/type/i));
+      await user.click(screen.getByRole('option', { name: /expense/i }));
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'EXPENSE',
+          categoryIds: [], // Categories reset when type changes
+        })
+      );
+    });
+
+    it('should reset category filter when changing type', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({
+        onFilterChange,
+        filter: {
+          type: 'EXPENSE',
+          categoryIds: ['cat-food'],
+        },
+      });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/type/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText(/type/i));
+      await user.click(screen.getByRole('option', { name: /income/i }));
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'INCOME',
+          categoryIds: [],
+        })
+      );
+    });
+
+    it('should clear type filter when selecting All Types', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({
+        onFilterChange,
+        filter: { type: 'EXPENSE' },
+      });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/type/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText(/type/i));
+      await user.click(screen.getByRole('option', { name: /all types/i }));
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: undefined,
+        })
+      );
+    });
+  });
+
+  describe('Category Filter', () => {
+    it('should load categories on mount', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter();
+
+      await user.click(screen.getByText('Filters'));
+
+      // Wait for categories to load
+      await waitFor(() => {
+        expect(screen.getByLabelText(/categories/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show all categories when no type is selected', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter();
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/categories/i)).toBeInTheDocument();
+      });
+
+      // Open categories dropdown
+      await user.click(screen.getByLabelText(/categories/i));
+
+      await waitFor(() => {
+        expect(screen.getByText('Salary')).toBeInTheDocument();
+        expect(screen.getByText('Freelance')).toBeInTheDocument();
+        expect(screen.getByText('Food & Dining')).toBeInTheDocument();
+        expect(screen.getByText('Transportation')).toBeInTheDocument();
+      });
+    });
+
+    it('should show only expense categories when EXPENSE type is selected', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter({ filter: { type: 'EXPENSE' } });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/categories/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText(/categories/i));
+
+      await waitFor(() => {
+        expect(screen.getByText('Food & Dining')).toBeInTheDocument();
+        expect(screen.getByText('Transportation')).toBeInTheDocument();
+        expect(screen.queryByText('Salary')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Amount Filter', () => {
+    it('should call onFilterChange when setting min amount', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({ onFilterChange });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/min amount/i)).toBeInTheDocument();
+      });
+
+      const minAmountInput = screen.getByLabelText(/min amount/i);
+      await user.type(minAmountInput, '50');
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          minAmount: 50,
+        })
+      );
+    });
+
+    it('should call onFilterChange when setting max amount', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({ onFilterChange });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/max amount/i)).toBeInTheDocument();
+      });
+
+      const maxAmountInput = screen.getByLabelText(/max amount/i);
+      await user.type(maxAmountInput, '500');
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxAmount: 500,
+        })
+      );
+    });
+
+    it('should clear amount filter when input is emptied', async () => {
+      const user = userEvent.setup();
+      const onFilterChange = vi.fn();
+      renderTransactionFilter({
+        onFilterChange,
+        filter: { minAmount: 50 },
+      });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/min amount/i)).toBeInTheDocument();
+      });
+
+      const minAmountInput = screen.getByLabelText(/min amount/i) as HTMLInputElement;
+      await user.clear(minAmountInput);
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          minAmount: undefined,
+        })
+      );
+    });
+  });
+
+  describe('Clear Filters', () => {
+    it('should call onClear when clicking Clear Filters button', async () => {
+      const user = userEvent.setup();
+      const onClear = vi.fn();
+      renderTransactionFilter({
+        onClear,
+        filter: { type: 'EXPENSE' },
+      });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /clear filters/i }));
+
+      expect(onClear).toHaveBeenCalled();
+    });
+
+    it('should disable Clear Filters button when no filters are active', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter({ filter: {} });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        const clearButton = screen.getByRole('button', { name: /clear filters/i });
+        expect(clearButton).toBeDisabled();
+      });
+    });
+
+    it('should enable Clear Filters button when filters are active', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter({ filter: { type: 'EXPENSE' } });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        const clearButton = screen.getByRole('button', { name: /clear filters/i });
+        expect(clearButton).not.toBeDisabled();
+      });
+    });
+  });
+
+  describe('Collapse/Expand', () => {
+    it('should collapse when clicking header again', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter();
+
+      // Expand
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/date range/i)).toBeInTheDocument();
+      });
+
+      // Collapse
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/date range/i)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should have accessible expand/collapse button', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter();
+
+      expect(screen.getByRole('button', { name: /expand filters/i })).toBeInTheDocument();
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /collapse filters/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Preserved Filter Values', () => {
+    it('should show current filter values when expanded', async () => {
+      const user = userEvent.setup();
+      renderTransactionFilter({
+        filter: {
+          startDate: '2026-01-01',
+          endDate: '2026-01-31',
+          minAmount: 50,
+          maxAmount: 500,
+        },
+      });
+
+      await user.click(screen.getByText('Filters'));
+
+      await waitFor(() => {
+        const startDateInput = screen.getByLabelText(/start date/i) as HTMLInputElement;
+        const endDateInput = screen.getByLabelText(/end date/i) as HTMLInputElement;
+        const minAmountInput = screen.getByLabelText(/min amount/i) as HTMLInputElement;
+        const maxAmountInput = screen.getByLabelText(/max amount/i) as HTMLInputElement;
+
+        expect(startDateInput.value).toBe('2026-01-01');
+        expect(endDateInput.value).toBe('2026-01-31');
+        expect(minAmountInput.value).toBe('50');
+        expect(maxAmountInput.value).toBe('500');
+      });
+    });
+  });
+});

--- a/frontend/src/components/transactions/TransactionFilter.tsx
+++ b/frontend/src/components/transactions/TransactionFilter.tsx
@@ -1,0 +1,364 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Paper,
+  Grid,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  Button,
+  Chip,
+  Typography,
+  Collapse,
+  IconButton,
+  Checkbox,
+  ListItemText,
+  OutlinedInput,
+  SelectChangeEvent,
+} from '@mui/material';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import ClearIcon from '@mui/icons-material/Clear';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import type {
+  TransactionFilter as TransactionFilterType,
+  TransactionType,
+  Category,
+  CategoriesResponse,
+  DateRangePreset,
+} from '@/types';
+import { categoryApi, getErrorMessage } from '@/api';
+
+interface TransactionFilterProps {
+  filter: TransactionFilterType;
+  onFilterChange: (filter: TransactionFilterType) => void;
+  onClear: () => void;
+}
+
+const DATE_PRESETS: { value: DateRangePreset; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'last7days', label: 'Last 7 Days' },
+  { value: 'last30days', label: 'Last 30 Days' },
+  { value: 'thisMonth', label: 'This Month' },
+  { value: 'lastMonth', label: 'Last Month' },
+  { value: 'thisYear', label: 'This Year' },
+  { value: 'custom', label: 'Custom Range' },
+];
+
+/**
+ * Calculate date range based on preset
+ */
+const getDateRange = (
+  preset: DateRangePreset
+): { startDate: string; endDate: string } | null => {
+  const today = new Date();
+  const formatDate = (date: Date): string => date.toISOString().split('T')[0];
+
+  switch (preset) {
+    case 'today':
+      return { startDate: formatDate(today), endDate: formatDate(today) };
+    case 'last7days': {
+      const start = new Date(today);
+      start.setDate(start.getDate() - 6);
+      return { startDate: formatDate(start), endDate: formatDate(today) };
+    }
+    case 'last30days': {
+      const start = new Date(today);
+      start.setDate(start.getDate() - 29);
+      return { startDate: formatDate(start), endDate: formatDate(today) };
+    }
+    case 'thisMonth': {
+      const start = new Date(today.getFullYear(), today.getMonth(), 1);
+      return { startDate: formatDate(start), endDate: formatDate(today) };
+    }
+    case 'lastMonth': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+      const end = new Date(today.getFullYear(), today.getMonth(), 0);
+      return { startDate: formatDate(start), endDate: formatDate(end) };
+    }
+    case 'thisYear': {
+      const start = new Date(today.getFullYear(), 0, 1);
+      return { startDate: formatDate(start), endDate: formatDate(today) };
+    }
+    case 'custom':
+      return null;
+    default:
+      return null;
+  }
+};
+
+/**
+ * TransactionFilter - Filter panel for transactions
+ * Supports date range, type, category, and amount filters
+ */
+const TransactionFilter: React.FC<TransactionFilterProps> = ({
+  filter,
+  onFilterChange,
+  onClear,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const [datePreset, setDatePreset] = useState<DateRangePreset | ''>('');
+  const [categories, setCategories] = useState<CategoriesResponse | null>(null);
+  const [loadingCategories, setLoadingCategories] = useState(false);
+
+  // Fetch categories on mount
+  useEffect(() => {
+    const fetchCategories = async () => {
+      setLoadingCategories(true);
+      try {
+        const data = await categoryApi.getCategories();
+        setCategories(data);
+      } catch (err) {
+        console.error('Failed to fetch categories:', getErrorMessage(err));
+      } finally {
+        setLoadingCategories(false);
+      }
+    };
+    fetchCategories();
+  }, []);
+
+  // Get all categories based on selected type
+  const getAvailableCategories = useCallback((): Category[] => {
+    if (!categories) return [];
+    if (filter.type === 'INCOME') return categories.income;
+    if (filter.type === 'EXPENSE') return categories.expense;
+    return [...categories.income, ...categories.expense];
+  }, [categories, filter.type]);
+
+  const availableCategories = getAvailableCategories();
+
+  // Count active filters
+  const activeFilterCount = [
+    filter.startDate,
+    filter.endDate,
+    filter.type,
+    filter.categoryIds && filter.categoryIds.length > 0,
+    filter.minAmount,
+    filter.maxAmount,
+  ].filter(Boolean).length;
+
+  const handleDatePresetChange = (event: SelectChangeEvent<string>) => {
+    const preset = event.target.value as DateRangePreset | '';
+    setDatePreset(preset);
+
+    if (preset && preset !== 'custom') {
+      const range = getDateRange(preset);
+      if (range) {
+        onFilterChange({ ...filter, ...range });
+      }
+    }
+  };
+
+  const handleTypeChange = (event: SelectChangeEvent<string>) => {
+    const type = event.target.value as TransactionType | '';
+    onFilterChange({
+      ...filter,
+      type: type || undefined,
+      categoryIds: [], // Reset categories when type changes
+    });
+  };
+
+  const handleCategoryChange = (event: SelectChangeEvent<string[]>) => {
+    const value = event.target.value;
+    const categoryIds = typeof value === 'string' ? value.split(',') : value;
+    onFilterChange({ ...filter, categoryIds });
+  };
+
+  const handleDateChange =
+    (field: 'startDate' | 'endDate') =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setDatePreset('custom');
+      onFilterChange({ ...filter, [field]: event.target.value || undefined });
+    };
+
+  const handleAmountChange =
+    (field: 'minAmount' | 'maxAmount') =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      onFilterChange({
+        ...filter,
+        [field]: value ? parseFloat(value) : undefined,
+      });
+    };
+
+  const handleClearFilters = () => {
+    setDatePreset('');
+    onClear();
+  };
+
+  const toggleExpanded = () => {
+    setExpanded((prev) => !prev);
+  };
+
+  return (
+    <Paper sx={{ p: 2 }}>
+      {/* Filter header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: 'pointer',
+        }}
+        onClick={toggleExpanded}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <FilterListIcon color="action" />
+          <Typography variant="subtitle1" fontWeight={500}>
+            Filters
+          </Typography>
+          {activeFilterCount > 0 && (
+            <Chip
+              size="small"
+              label={activeFilterCount}
+              color="primary"
+              sx={{ ml: 1 }}
+            />
+          )}
+        </Box>
+        <IconButton size="small" aria-label={expanded ? 'Collapse filters' : 'Expand filters'}>
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+
+      {/* Filter content */}
+      <Collapse in={expanded}>
+        <Box sx={{ mt: 2 }}>
+          <Grid container spacing={2}>
+            {/* Date preset */}
+            <Grid item xs={12} sm={6} md={3}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Date Range</InputLabel>
+                <Select
+                  value={datePreset}
+                  label="Date Range"
+                  onChange={handleDatePresetChange}
+                >
+                  <MenuItem value="">
+                    <em>All Time</em>
+                  </MenuItem>
+                  {DATE_PRESETS.map((preset) => (
+                    <MenuItem key={preset.value} value={preset.value}>
+                      {preset.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+
+            {/* Custom date range */}
+            <Grid item xs={6} sm={3} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Start Date"
+                type="date"
+                value={filter.startDate || ''}
+                onChange={handleDateChange('startDate')}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid item xs={6} sm={3} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="End Date"
+                type="date"
+                value={filter.endDate || ''}
+                onChange={handleDateChange('endDate')}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+
+            {/* Type filter */}
+            <Grid item xs={12} sm={6} md={2}>
+              <FormControl fullWidth size="small">
+                <InputLabel>Type</InputLabel>
+                <Select
+                  value={filter.type || ''}
+                  label="Type"
+                  onChange={handleTypeChange}
+                >
+                  <MenuItem value="">
+                    <em>All Types</em>
+                  </MenuItem>
+                  <MenuItem value="INCOME">Income</MenuItem>
+                  <MenuItem value="EXPENSE">Expense</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+
+            {/* Category filter */}
+            <Grid item xs={12} sm={6} md={3}>
+              <FormControl fullWidth size="small" disabled={loadingCategories}>
+                <InputLabel>Categories</InputLabel>
+                <Select
+                  multiple
+                  value={filter.categoryIds || []}
+                  onChange={handleCategoryChange}
+                  input={<OutlinedInput label="Categories" />}
+                  renderValue={(selected) => {
+                    const selectedNames = selected
+                      .map((id) => availableCategories.find((c) => c.id === id)?.name)
+                      .filter(Boolean);
+                    return selectedNames.join(', ');
+                  }}
+                >
+                  {availableCategories.map((category) => (
+                    <MenuItem key={category.id} value={category.id}>
+                      <Checkbox
+                        checked={(filter.categoryIds || []).includes(category.id)}
+                      />
+                      <ListItemText primary={category.name} />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Grid>
+
+            {/* Amount range */}
+            <Grid item xs={6} sm={3} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Min Amount"
+                type="number"
+                value={filter.minAmount ?? ''}
+                onChange={handleAmountChange('minAmount')}
+                InputProps={{ inputProps: { min: 0, step: 0.01 } }}
+              />
+            </Grid>
+            <Grid item xs={6} sm={3} md={2}>
+              <TextField
+                fullWidth
+                size="small"
+                label="Max Amount"
+                type="number"
+                value={filter.maxAmount ?? ''}
+                onChange={handleAmountChange('maxAmount')}
+                InputProps={{ inputProps: { min: 0, step: 0.01 } }}
+              />
+            </Grid>
+
+            {/* Clear button */}
+            <Grid item xs={12}>
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <Button
+                  startIcon={<ClearIcon />}
+                  onClick={handleClearFilters}
+                  disabled={activeFilterCount === 0}
+                >
+                  Clear Filters
+                </Button>
+              </Box>
+            </Grid>
+          </Grid>
+        </Box>
+      </Collapse>
+    </Paper>
+  );
+};
+
+export default TransactionFilter;

--- a/frontend/src/components/transactions/TransactionForm.test.tsx
+++ b/frontend/src/components/transactions/TransactionForm.test.tsx
@@ -1,0 +1,458 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material';
+import TransactionForm from './TransactionForm';
+import type { Transaction, CreateTransactionRequest } from '@/types';
+
+const theme = createTheme();
+
+// Mock the CategorySelect component
+vi.mock('./CategorySelect', () => ({
+  default: ({
+    transactionType,
+    value,
+    onChange,
+    error,
+    helperText,
+  }: {
+    transactionType: string;
+    value: string;
+    onChange: (id: string) => void;
+    error: boolean;
+    helperText?: string;
+  }) => (
+    <div data-testid="category-select">
+      <select
+        data-testid="category-dropdown"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Category"
+      >
+        <option value="">Select category</option>
+        {transactionType === 'EXPENSE' ? (
+          <>
+            <option value="cat-food">Food & Dining</option>
+            <option value="cat-transport">Transportation</option>
+          </>
+        ) : (
+          <>
+            <option value="cat-salary">Salary</option>
+            <option value="cat-freelance">Freelance</option>
+          </>
+        )}
+      </select>
+      {error && <span data-testid="category-error">{helperText}</span>}
+    </div>
+  ),
+}));
+
+const mockTransaction: Transaction = {
+  id: '1',
+  amount: 150.0,
+  type: 'EXPENSE',
+  category: {
+    id: 'cat-food',
+    name: 'Food & Dining',
+    type: 'EXPENSE',
+    icon: 'restaurant',
+    color: '#F44336',
+  },
+  date: '2026-01-20',
+  description: 'Grocery shopping',
+  notes: 'Weekly groceries',
+  createdAt: '2026-01-20T14:30:00Z',
+  updatedAt: '2026-01-20T14:30:00Z',
+};
+
+const defaultProps = {
+  transaction: null,
+  onSubmit: vi.fn(),
+  onCancel: vi.fn(),
+  loading: false,
+  error: null,
+};
+
+const renderTransactionForm = (props = {}) => {
+  return render(
+    <ThemeProvider theme={theme}>
+      <TransactionForm {...defaultProps} {...props} />
+    </ThemeProvider>
+  );
+};
+
+describe('TransactionForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering - Create Mode', () => {
+    it('should render all form fields', () => {
+      renderTransactionForm();
+
+      expect(screen.getByLabelText(/expense/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/income/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
+      expect(screen.getByTestId('category-select')).toBeInTheDocument();
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
+    });
+
+    it('should default to EXPENSE type', () => {
+      renderTransactionForm();
+
+      const expenseRadio = screen.getByLabelText(/expense/i) as HTMLInputElement;
+      const incomeRadio = screen.getByLabelText(/income/i) as HTMLInputElement;
+
+      expect(expenseRadio.checked).toBe(true);
+      expect(incomeRadio.checked).toBe(false);
+    });
+
+    it('should default date to today', () => {
+      renderTransactionForm();
+
+      const dateInput = screen.getByLabelText(/date/i) as HTMLInputElement;
+      const today = new Date().toISOString().split('T')[0];
+
+      expect(dateInput.value).toBe(today);
+    });
+
+    it('should show Create Transaction button', () => {
+      renderTransactionForm();
+
+      expect(screen.getByRole('button', { name: /create transaction/i })).toBeInTheDocument();
+    });
+
+    it('should show Cancel button', () => {
+      renderTransactionForm();
+
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Rendering - Edit Mode', () => {
+    it('should pre-fill form with transaction data', () => {
+      renderTransactionForm({ transaction: mockTransaction });
+
+      const amountInput = screen.getByLabelText(/amount/i) as HTMLInputElement;
+      expect(amountInput.value).toBe('150');
+
+      const expenseRadio = screen.getByLabelText(/expense/i) as HTMLInputElement;
+      expect(expenseRadio.checked).toBe(true);
+
+      const dateInput = screen.getByLabelText(/date/i) as HTMLInputElement;
+      expect(dateInput.value).toBe('2026-01-20');
+
+      const descriptionInput = screen.getByLabelText(/description/i) as HTMLInputElement;
+      expect(descriptionInput.value).toBe('Grocery shopping');
+
+      const notesInput = screen.getByLabelText(/notes/i) as HTMLInputElement;
+      expect(notesInput.value).toBe('Weekly groceries');
+    });
+
+    it('should show Update Transaction button in edit mode', () => {
+      renderTransactionForm({ transaction: mockTransaction });
+
+      expect(screen.getByRole('button', { name: /update transaction/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Validation', () => {
+    it('should show error when amount is empty', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      // Fill in other required fields
+      await user.type(screen.getByLabelText(/date/i), '2026-01-20');
+
+      // Try to submit
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/amount is required/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when amount is zero', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const amountInput = screen.getByLabelText(/amount/i);
+      await user.type(amountInput, '0');
+
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/amount must be greater than 0/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when amount is negative', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const amountInput = screen.getByLabelText(/amount/i);
+      await user.type(amountInput, '-100');
+
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/amount must be greater than 0/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when amount exceeds maximum', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const amountInput = screen.getByLabelText(/amount/i);
+      await user.type(amountInput, '10000001');
+
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/must not exceed/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when category is not selected', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const amountInput = screen.getByLabelText(/amount/i);
+      await user.type(amountInput, '100');
+
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('category-error')).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when description exceeds 500 characters', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const longDescription = 'a'.repeat(501);
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(descriptionInput, longDescription);
+
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/description must be 500 characters or less/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when notes exceeds 1000 characters', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const longNotes = 'a'.repeat(1001);
+      const notesInput = screen.getByLabelText(/notes/i);
+      await user.type(notesInput, longNotes);
+
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/notes must be 1000 characters or less/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show warning for future date', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const dateInput = screen.getByLabelText(/date/i);
+      await user.clear(dateInput);
+      await user.type(dateInput, '2030-12-31');
+
+      await waitFor(() => {
+        expect(screen.getByText(/transaction date is in the future/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Form Submission', () => {
+    it('should call onSubmit with correct data for create', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderTransactionForm({ onSubmit });
+
+      // Fill in the form
+      await user.type(screen.getByLabelText(/amount/i), '150');
+      await user.clear(screen.getByLabelText(/date/i));
+      await user.type(screen.getByLabelText(/date/i), '2026-01-20');
+
+      // Select category
+      const categoryDropdown = screen.getByTestId('category-dropdown');
+      await user.selectOptions(categoryDropdown, 'cat-food');
+
+      await user.type(screen.getByLabelText(/description/i), 'Test description');
+      await user.type(screen.getByLabelText(/notes/i), 'Test notes');
+
+      // Submit
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith({
+          amount: 150,
+          type: 'EXPENSE',
+          categoryId: 'cat-food',
+          date: '2026-01-20',
+          description: 'Test description',
+          notes: 'Test notes',
+        });
+      });
+    });
+
+    it('should call onSubmit with null for empty optional fields', async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn().mockResolvedValue(undefined);
+      renderTransactionForm({ onSubmit });
+
+      // Fill in required fields only
+      await user.type(screen.getByLabelText(/amount/i), '100');
+      await user.clear(screen.getByLabelText(/date/i));
+      await user.type(screen.getByLabelText(/date/i), '2026-01-20');
+
+      const categoryDropdown = screen.getByTestId('category-dropdown');
+      await user.selectOptions(categoryDropdown, 'cat-food');
+
+      await user.click(screen.getByRole('button', { name: /create transaction/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith({
+          amount: 100,
+          type: 'EXPENSE',
+          categoryId: 'cat-food',
+          date: '2026-01-20',
+          description: null,
+          notes: null,
+        });
+      });
+    });
+
+    it('should call onCancel when clicking cancel button', async () => {
+      const user = userEvent.setup();
+      const onCancel = vi.fn();
+      renderTransactionForm({ onCancel });
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('Type Switching', () => {
+    it('should switch to INCOME type when selected', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      await user.click(screen.getByLabelText(/income/i));
+
+      const incomeRadio = screen.getByLabelText(/income/i) as HTMLInputElement;
+      expect(incomeRadio.checked).toBe(true);
+
+      // Category options should change to income categories
+      const categoryDropdown = screen.getByTestId('category-dropdown');
+      expect(categoryDropdown).toContainHTML('Salary');
+      expect(categoryDropdown).toContainHTML('Freelance');
+    });
+
+    it('should switch back to EXPENSE type', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      await user.click(screen.getByLabelText(/income/i));
+      await user.click(screen.getByLabelText(/expense/i));
+
+      const expenseRadio = screen.getByLabelText(/expense/i) as HTMLInputElement;
+      expect(expenseRadio.checked).toBe(true);
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should disable form during loading', () => {
+      renderTransactionForm({ loading: true });
+
+      expect(screen.getByLabelText(/amount/i)).toBeDisabled();
+      expect(screen.getByRole('button', { name: /creating/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+    });
+
+    it('should show Creating... text during create submission', () => {
+      renderTransactionForm({ loading: true });
+
+      expect(screen.getByRole('button', { name: /creating/i })).toBeInTheDocument();
+    });
+
+    it('should show Updating... text during update submission', () => {
+      renderTransactionForm({ loading: true, transaction: mockTransaction });
+
+      expect(screen.getByRole('button', { name: /updating/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Display', () => {
+    it('should show error alert when error prop is set', () => {
+      renderTransactionForm({ error: 'Failed to create transaction' });
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to create transaction');
+    });
+
+    it('should not show error alert when error prop is null', () => {
+      renderTransactionForm({ error: null });
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Character Counters', () => {
+    it('should show character counter for description', () => {
+      renderTransactionForm();
+
+      expect(screen.getByText('0/500')).toBeInTheDocument();
+    });
+
+    it('should show character counter for notes', () => {
+      renderTransactionForm();
+
+      expect(screen.getByText('0/1000')).toBeInTheDocument();
+    });
+
+    it('should update character counter as user types', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm();
+
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(descriptionInput, 'Test');
+
+      expect(screen.getByText('4/500')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edit Mode - No Changes', () => {
+    it('should disable submit button when no changes made in edit mode', () => {
+      renderTransactionForm({ transaction: mockTransaction });
+
+      const submitButton = screen.getByRole('button', { name: /update transaction/i });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it('should enable submit button when changes are made in edit mode', async () => {
+      const user = userEvent.setup();
+      renderTransactionForm({ transaction: mockTransaction });
+
+      const amountInput = screen.getByLabelText(/amount/i);
+      await user.clear(amountInput);
+      await user.type(amountInput, '200');
+
+      await waitFor(() => {
+        const submitButton = screen.getByRole('button', { name: /update transaction/i });
+        expect(submitButton).not.toBeDisabled();
+      });
+    });
+  });
+});

--- a/frontend/src/components/transactions/TransactionForm.tsx
+++ b/frontend/src/components/transactions/TransactionForm.tsx
@@ -1,0 +1,329 @@
+import React, { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import {
+  Box,
+  TextField,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Button,
+  Grid,
+  Alert,
+  CircularProgress,
+  FormHelperText,
+} from '@mui/material';
+import SaveIcon from '@mui/icons-material/Save';
+import type {
+  TransactionType,
+  CreateTransactionRequest,
+  UpdateTransactionRequest,
+  Transaction,
+} from '@/types';
+import CategorySelect from './CategorySelect';
+
+interface TransactionFormData {
+  amount: string;
+  type: TransactionType;
+  categoryId: string;
+  date: string;
+  description: string;
+  notes: string;
+}
+
+interface TransactionFormProps {
+  transaction?: Transaction | null;
+  onSubmit: (data: CreateTransactionRequest | UpdateTransactionRequest) => Promise<void>;
+  onCancel: () => void;
+  loading?: boolean;
+  error?: string | null;
+}
+
+const MAX_AMOUNT = 10000000;
+const MAX_DESCRIPTION_LENGTH = 500;
+const MAX_NOTES_LENGTH = 1000;
+
+/**
+ * Get today's date in YYYY-MM-DD format
+ */
+const getTodayDate = (): string => {
+  return new Date().toISOString().split('T')[0];
+};
+
+/**
+ * TransactionForm - Form for creating/editing transactions
+ * Handles validation and submission of transaction data
+ */
+const TransactionForm: React.FC<TransactionFormProps> = ({
+  transaction,
+  onSubmit,
+  onCancel,
+  loading = false,
+  error = null,
+}) => {
+  const isEditing = !!transaction;
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    reset,
+    setValue,
+    formState: { errors, isValid, isDirty },
+  } = useForm<TransactionFormData>({
+    mode: 'onChange',
+    defaultValues: {
+      amount: transaction?.amount?.toString() || '',
+      type: transaction?.type || 'EXPENSE',
+      categoryId: transaction?.category?.id || '',
+      date: transaction?.date || getTodayDate(),
+      description: transaction?.description || '',
+      notes: transaction?.notes || '',
+    },
+  });
+
+  const transactionType = watch('type');
+
+  // Reset form when transaction changes
+  useEffect(() => {
+    if (transaction) {
+      reset({
+        amount: transaction.amount.toString(),
+        type: transaction.type,
+        categoryId: transaction.category.id,
+        date: transaction.date,
+        description: transaction.description || '',
+        notes: transaction.notes || '',
+      });
+    }
+  }, [transaction, reset]);
+
+  const handleFormSubmit = async (data: TransactionFormData) => {
+    const requestData: CreateTransactionRequest | UpdateTransactionRequest = {
+      amount: parseFloat(data.amount),
+      type: data.type,
+      categoryId: data.categoryId,
+      date: data.date,
+      description: data.description || null,
+      notes: data.notes || null,
+    };
+
+    await onSubmit(requestData);
+  };
+
+  const handleCategoryChange = (categoryId: string) => {
+    setValue('categoryId', categoryId, { shouldValidate: true, shouldDirty: true });
+  };
+
+  // Check if date is in the future
+  const dateValue = watch('date');
+  const isFutureDate = dateValue && new Date(dateValue) > new Date();
+
+  return (
+    <Box component="form" onSubmit={handleSubmit(handleFormSubmit)} noValidate>
+      {error && (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Grid container spacing={3}>
+        {/* Transaction Type */}
+        <Grid item xs={12}>
+          <FormControl component="fieldset">
+            <FormLabel component="legend">Transaction Type</FormLabel>
+            <Controller
+              name="type"
+              control={control}
+              render={({ field }) => (
+                <RadioGroup row {...field}>
+                  <FormControlLabel
+                    value="EXPENSE"
+                    control={<Radio color="error" />}
+                    label="Expense"
+                  />
+                  <FormControlLabel
+                    value="INCOME"
+                    control={<Radio color="success" />}
+                    label="Income"
+                  />
+                </RadioGroup>
+              )}
+            />
+          </FormControl>
+        </Grid>
+
+        {/* Amount */}
+        <Grid item xs={12} sm={6}>
+          <Controller
+            name="amount"
+            control={control}
+            rules={{
+              required: 'Amount is required',
+              validate: {
+                positive: (value) => {
+                  const num = parseFloat(value);
+                  return num > 0 || 'Amount must be greater than 0';
+                },
+                max: (value) => {
+                  const num = parseFloat(value);
+                  return num <= MAX_AMOUNT || `Amount must not exceed ${MAX_AMOUNT.toLocaleString()}`;
+                },
+              },
+            }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Amount"
+                type="number"
+                required
+                error={!!errors.amount}
+                helperText={errors.amount?.message}
+                InputProps={{
+                  startAdornment: <Box sx={{ mr: 0.5 }}>$</Box>,
+                  inputProps: { min: 0.01, step: 0.01, max: MAX_AMOUNT },
+                }}
+              />
+            )}
+          />
+        </Grid>
+
+        {/* Date */}
+        <Grid item xs={12} sm={6}>
+          <Controller
+            name="date"
+            control={control}
+            rules={{
+              required: 'Date is required',
+            }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Date"
+                type="date"
+                required
+                error={!!errors.date}
+                helperText={errors.date?.message}
+                InputLabelProps={{ shrink: true }}
+              />
+            )}
+          />
+          {isFutureDate && (
+            <FormHelperText sx={{ color: 'warning.main' }}>
+              Note: This transaction date is in the future.
+            </FormHelperText>
+          )}
+        </Grid>
+
+        {/* Category */}
+        <Grid item xs={12}>
+          <Controller
+            name="categoryId"
+            control={control}
+            rules={{
+              required: 'Category is required',
+            }}
+            render={({ field }) => (
+              <CategorySelect
+                transactionType={transactionType}
+                value={field.value}
+                onChange={handleCategoryChange}
+                error={!!errors.categoryId}
+                helperText={errors.categoryId?.message}
+              />
+            )}
+          />
+        </Grid>
+
+        {/* Description */}
+        <Grid item xs={12}>
+          <Controller
+            name="description"
+            control={control}
+            rules={{
+              maxLength: {
+                value: MAX_DESCRIPTION_LENGTH,
+                message: `Description must be ${MAX_DESCRIPTION_LENGTH} characters or less`,
+              },
+            }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Description"
+                placeholder="e.g., Grocery shopping at Whole Foods"
+                error={!!errors.description}
+                helperText={
+                  errors.description?.message ||
+                  `${field.value.length}/${MAX_DESCRIPTION_LENGTH}`
+                }
+              />
+            )}
+          />
+        </Grid>
+
+        {/* Notes */}
+        <Grid item xs={12}>
+          <Controller
+            name="notes"
+            control={control}
+            rules={{
+              maxLength: {
+                value: MAX_NOTES_LENGTH,
+                message: `Notes must be ${MAX_NOTES_LENGTH} characters or less`,
+              },
+            }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                fullWidth
+                label="Notes"
+                multiline
+                rows={3}
+                placeholder="Additional notes about this transaction..."
+                error={!!errors.notes}
+                helperText={
+                  errors.notes?.message || `${field.value.length}/${MAX_NOTES_LENGTH}`
+                }
+              />
+            )}
+          />
+        </Grid>
+
+        {/* Actions */}
+        <Grid item xs={12}>
+          <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
+            <Button
+              variant="outlined"
+              onClick={onCancel}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={loading || !isValid || (!isDirty && isEditing)}
+              startIcon={
+                loading ? <CircularProgress size={20} color="inherit" /> : <SaveIcon />
+              }
+            >
+              {loading
+                ? isEditing
+                  ? 'Updating...'
+                  : 'Creating...'
+                : isEditing
+                  ? 'Update Transaction'
+                  : 'Create Transaction'}
+            </Button>
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default TransactionForm;

--- a/frontend/src/components/transactions/TransactionList.test.tsx
+++ b/frontend/src/components/transactions/TransactionList.test.tsx
@@ -1,0 +1,462 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material';
+import TransactionList from './TransactionList';
+import type { Transaction, SortField, SortDirection } from '@/types';
+
+const theme = createTheme();
+
+const mockTransactions: Transaction[] = [
+  {
+    id: '1',
+    amount: 150.0,
+    type: 'EXPENSE',
+    category: {
+      id: 'cat-1',
+      name: 'Food & Dining',
+      type: 'EXPENSE',
+      icon: 'restaurant',
+      color: '#F44336',
+    },
+    date: '2026-01-20',
+    description: 'Grocery shopping at Whole Foods',
+    notes: 'Weekly groceries',
+    createdAt: '2026-01-20T14:30:00Z',
+    updatedAt: '2026-01-20T14:30:00Z',
+  },
+  {
+    id: '2',
+    amount: 5000.0,
+    type: 'INCOME',
+    category: {
+      id: 'cat-2',
+      name: 'Salary',
+      type: 'INCOME',
+      icon: 'payments',
+      color: '#4CAF50',
+    },
+    date: '2026-01-15',
+    description: 'Monthly salary',
+    notes: null,
+    createdAt: '2026-01-15T09:00:00Z',
+    updatedAt: '2026-01-15T09:00:00Z',
+  },
+  {
+    id: '3',
+    amount: 75.5,
+    type: 'EXPENSE',
+    category: {
+      id: 'cat-3',
+      name: 'Transportation',
+      type: 'EXPENSE',
+      icon: 'directions_car',
+      color: '#E91E63',
+    },
+    date: '2026-01-18',
+    description: 'Gas for car',
+    notes: 'Filled up at Shell station',
+    createdAt: '2026-01-18T16:45:00Z',
+    updatedAt: '2026-01-18T16:45:00Z',
+  },
+];
+
+const defaultProps = {
+  transactions: mockTransactions,
+  loading: false,
+  page: 0,
+  pageSize: 20,
+  totalElements: 3,
+  sortField: 'date' as SortField,
+  sortDirection: 'desc' as SortDirection,
+  onPageChange: vi.fn(),
+  onPageSizeChange: vi.fn(),
+  onSortChange: vi.fn(),
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+const renderTransactionList = (props = {}) => {
+  return render(
+    <ThemeProvider theme={theme}>
+      <TransactionList {...defaultProps} {...props} />
+    </ThemeProvider>
+  );
+};
+
+describe('TransactionList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render table with correct headers', () => {
+      renderTransactionList();
+
+      expect(screen.getByText('Date')).toBeInTheDocument();
+      expect(screen.getByText('Type')).toBeInTheDocument();
+      expect(screen.getByText('Category')).toBeInTheDocument();
+      expect(screen.getByText('Description')).toBeInTheDocument();
+      expect(screen.getByText('Amount')).toBeInTheDocument();
+      expect(screen.getByText('Actions')).toBeInTheDocument();
+    });
+
+    it('should render all transactions', () => {
+      renderTransactionList();
+
+      expect(screen.getByText('Grocery shopping at Whole Foods')).toBeInTheDocument();
+      expect(screen.getByText('Monthly salary')).toBeInTheDocument();
+      expect(screen.getByText('Gas for car')).toBeInTheDocument();
+    });
+
+    it('should format currency correctly', () => {
+      renderTransactionList();
+
+      expect(screen.getByText('-$150.00')).toBeInTheDocument();
+      expect(screen.getByText('+$5,000.00')).toBeInTheDocument();
+      expect(screen.getByText('-$75.50')).toBeInTheDocument();
+    });
+
+    it('should format dates correctly', () => {
+      renderTransactionList();
+
+      expect(screen.getByText('Jan 20, 2026')).toBeInTheDocument();
+      expect(screen.getByText('Jan 15, 2026')).toBeInTheDocument();
+      expect(screen.getByText('Jan 18, 2026')).toBeInTheDocument();
+    });
+
+    it('should display category names', () => {
+      renderTransactionList();
+
+      expect(screen.getByText('Food & Dining')).toBeInTheDocument();
+      expect(screen.getByText('Salary')).toBeInTheDocument();
+      expect(screen.getByText('Transportation')).toBeInTheDocument();
+    });
+
+    it('should display transaction type chips', () => {
+      renderTransactionList();
+
+      const expenseChips = screen.getAllByText('EXPENSE');
+      const incomeChips = screen.getAllByText('INCOME');
+
+      expect(expenseChips).toHaveLength(2);
+      expect(incomeChips).toHaveLength(1);
+    });
+
+    it('should show pagination info', () => {
+      renderTransactionList();
+
+      expect(screen.getByText('Showing 1-3 of 3 transactions')).toBeInTheDocument();
+    });
+  });
+
+  describe('Empty State', () => {
+    it('should show empty message when no transactions', () => {
+      renderTransactionList({ transactions: [], totalElements: 0 });
+
+      expect(screen.getByText('No transactions yet')).toBeInTheDocument();
+      expect(
+        screen.getByText('Create your first transaction to get started.')
+      ).toBeInTheDocument();
+    });
+
+    it('should show "No transactions" in pagination when empty', () => {
+      renderTransactionList({ transactions: [], totalElements: 0 });
+
+      expect(screen.getByText('No transactions')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should show skeleton loading when loading', () => {
+      renderTransactionList({ loading: true });
+
+      // Check for skeleton elements (MUI renders multiple circular skeletons)
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+    });
+
+    it('should not show transactions when loading', () => {
+      renderTransactionList({ loading: true });
+
+      expect(screen.queryByText('Grocery shopping at Whole Foods')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Sorting', () => {
+    it('should call onSortChange when clicking Date header', async () => {
+      const user = userEvent.setup();
+      const onSortChange = vi.fn();
+      renderTransactionList({ onSortChange });
+
+      await user.click(screen.getByText('Date'));
+
+      expect(onSortChange).toHaveBeenCalledWith('date', 'asc');
+    });
+
+    it('should toggle sort direction when clicking same header', async () => {
+      const user = userEvent.setup();
+      const onSortChange = vi.fn();
+      renderTransactionList({ onSortChange, sortField: 'date', sortDirection: 'asc' });
+
+      await user.click(screen.getByText('Date'));
+
+      expect(onSortChange).toHaveBeenCalledWith('date', 'desc');
+    });
+
+    it('should call onSortChange when clicking Amount header', async () => {
+      const user = userEvent.setup();
+      const onSortChange = vi.fn();
+      renderTransactionList({ onSortChange });
+
+      await user.click(screen.getByText('Amount'));
+
+      expect(onSortChange).toHaveBeenCalledWith('amount', 'asc');
+    });
+
+    it('should call onSortChange when clicking Category header', async () => {
+      const user = userEvent.setup();
+      const onSortChange = vi.fn();
+      renderTransactionList({ onSortChange });
+
+      await user.click(screen.getByText('Category'));
+
+      expect(onSortChange).toHaveBeenCalledWith('category', 'asc');
+    });
+  });
+
+  describe('Pagination', () => {
+    it('should call onPageChange when clicking next page', async () => {
+      const user = userEvent.setup();
+      const onPageChange = vi.fn();
+      renderTransactionList({ onPageChange, totalElements: 50 });
+
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+
+      expect(onPageChange).toHaveBeenCalledWith(1);
+    });
+
+    it('should call onPageSizeChange when changing rows per page', async () => {
+      const user = userEvent.setup();
+      const onPageSizeChange = vi.fn();
+      const onPageChange = vi.fn();
+      renderTransactionList({ onPageSizeChange, onPageChange });
+
+      // Open the rows per page dropdown
+      const select = screen.getByRole('combobox');
+      await user.click(select);
+
+      // Select 50 rows per page
+      const option50 = screen.getByRole('option', { name: '50' });
+      await user.click(option50);
+
+      expect(onPageSizeChange).toHaveBeenCalledWith(50);
+      expect(onPageChange).toHaveBeenCalledWith(0);
+    });
+
+    it('should disable previous button on first page', () => {
+      renderTransactionList({ page: 0 });
+
+      const prevButton = screen.getByRole('button', { name: /previous page/i });
+      expect(prevButton).toBeDisabled();
+    });
+
+    it('should disable next button on last page', () => {
+      renderTransactionList({ page: 0, pageSize: 20, totalElements: 3 });
+
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      expect(nextButton).toBeDisabled();
+    });
+  });
+
+  describe('Actions', () => {
+    it('should call onEdit when clicking edit button', async () => {
+      const user = userEvent.setup();
+      const onEdit = vi.fn();
+      renderTransactionList({ onEdit });
+
+      const editButtons = screen.getAllByRole('button', { name: /edit transaction/i });
+      await user.click(editButtons[0]);
+
+      expect(onEdit).toHaveBeenCalledWith(mockTransactions[0]);
+    });
+
+    it('should call onDelete when clicking delete button', async () => {
+      const user = userEvent.setup();
+      const onDelete = vi.fn();
+      renderTransactionList({ onDelete });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete transaction/i });
+      await user.click(deleteButtons[0]);
+
+      expect(onDelete).toHaveBeenCalledWith(mockTransactions[0]);
+    });
+
+    it('should not trigger row expansion when clicking edit', async () => {
+      const user = userEvent.setup();
+      const onEdit = vi.fn();
+      renderTransactionList({ onEdit });
+
+      const editButtons = screen.getAllByRole('button', { name: /edit transaction/i });
+      await user.click(editButtons[0]);
+
+      // Check that expanded details are not shown
+      expect(screen.queryByText('Transaction Details')).not.toBeInTheDocument();
+    });
+
+    it('should not trigger row expansion when clicking delete', async () => {
+      const user = userEvent.setup();
+      const onDelete = vi.fn();
+      renderTransactionList({ onDelete });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete transaction/i });
+      await user.click(deleteButtons[0]);
+
+      expect(screen.queryByText('Transaction Details')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Row Expansion', () => {
+    it('should expand row when clicking on it', async () => {
+      const user = userEvent.setup();
+      renderTransactionList();
+
+      // Click on the first row (find the row and click it)
+      const expandButton = screen.getAllByRole('button', { name: /expand details/i })[0];
+      await user.click(expandButton);
+
+      expect(screen.getByText('Transaction Details')).toBeInTheDocument();
+      expect(screen.getByText('Weekly groceries')).toBeInTheDocument();
+    });
+
+    it('should collapse row when clicking again', async () => {
+      const user = userEvent.setup();
+      renderTransactionList();
+
+      const expandButton = screen.getAllByRole('button', { name: /expand details/i })[0];
+      await user.click(expandButton);
+
+      expect(screen.getByText('Transaction Details')).toBeInTheDocument();
+
+      const collapseButton = screen.getByRole('button', { name: /collapse details/i });
+      await user.click(collapseButton);
+
+      // Wait for collapse animation
+      await vi.waitFor(() => {
+        expect(screen.queryByText('Transaction Details')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show notes in expanded view', async () => {
+      const user = userEvent.setup();
+      renderTransactionList();
+
+      const expandButton = screen.getAllByRole('button', { name: /expand details/i })[0];
+      await user.click(expandButton);
+
+      expect(screen.getByText('Notes')).toBeInTheDocument();
+      expect(screen.getByText('Weekly groceries')).toBeInTheDocument();
+    });
+
+    it('should show "-" for missing notes in expanded view', async () => {
+      const user = userEvent.setup();
+      renderTransactionList();
+
+      // Expand the second row (Monthly salary has no notes)
+      const expandButtons = screen.getAllByRole('button', { name: /expand details/i });
+      await user.click(expandButtons[1]);
+
+      const notesSection = screen.getByText('Notes').parentElement;
+      expect(notesSection).toContainHTML('-');
+    });
+  });
+
+  describe('Description Truncation', () => {
+    it('should truncate long descriptions', () => {
+      const longDescription =
+        'This is a very long description that exceeds fifty characters and should be truncated';
+      const transactionWithLongDesc: Transaction[] = [
+        {
+          ...mockTransactions[0],
+          description: longDescription,
+        },
+      ];
+
+      renderTransactionList({ transactions: transactionWithLongDesc, totalElements: 1 });
+
+      // Check that the truncated text is shown (50 chars + "...")
+      expect(
+        screen.getByText('This is a very long description that exceeds fift...')
+      ).toBeInTheDocument();
+    });
+
+    it('should show full description on hover via tooltip', () => {
+      renderTransactionList();
+
+      // Tooltip is shown on hover - we just verify the tooltip component exists
+      const descriptionCell = screen.getByText('Grocery shopping at Whole Foods');
+      expect(descriptionCell).toBeInTheDocument();
+    });
+
+    it('should show "-" for null description', () => {
+      const transactionWithNoDesc: Transaction[] = [
+        {
+          ...mockTransactions[0],
+          description: null,
+        },
+      ];
+
+      renderTransactionList({ transactions: transactionWithNoDesc, totalElements: 1 });
+
+      // The cell should show "-"
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('-');
+    });
+  });
+
+  describe('Visual Indicators', () => {
+    it('should show green color for income amounts', () => {
+      renderTransactionList();
+
+      const incomeAmount = screen.getByText('+$5,000.00');
+      expect(incomeAmount).toHaveStyle({ fontWeight: 600 });
+    });
+
+    it('should show red color for expense amounts', () => {
+      renderTransactionList();
+
+      const expenseAmount = screen.getByText('-$150.00');
+      expect(expenseAmount).toHaveStyle({ fontWeight: 600 });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have accessible table', () => {
+      renderTransactionList();
+
+      expect(screen.getByRole('table', { name: /transactions table/i })).toBeInTheDocument();
+    });
+
+    it('should have accessible edit buttons', () => {
+      renderTransactionList();
+
+      const editButtons = screen.getAllByRole('button', { name: /edit transaction/i });
+      expect(editButtons).toHaveLength(3);
+    });
+
+    it('should have accessible delete buttons', () => {
+      renderTransactionList();
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete transaction/i });
+      expect(deleteButtons).toHaveLength(3);
+    });
+
+    it('should have accessible expand/collapse buttons', () => {
+      renderTransactionList();
+
+      const expandButtons = screen.getAllByRole('button', { name: /expand details/i });
+      expect(expandButtons).toHaveLength(3);
+    });
+  });
+});

--- a/frontend/src/components/transactions/TransactionList.tsx
+++ b/frontend/src/components/transactions/TransactionList.tsx
@@ -1,0 +1,386 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TablePagination,
+  TableSortLabel,
+  IconButton,
+  Chip,
+  Typography,
+  Tooltip,
+  Skeleton,
+  Collapse,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import Icon from '@mui/material/Icon';
+import type { Transaction, SortField, SortDirection } from '@/types';
+
+interface TransactionListProps {
+  transactions: Transaction[];
+  loading?: boolean;
+  page: number;
+  pageSize: number;
+  totalElements: number;
+  sortField: SortField;
+  sortDirection: SortDirection;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  onSortChange: (field: SortField, direction: SortDirection) => void;
+  onEdit: (transaction: Transaction) => void;
+  onDelete: (transaction: Transaction) => void;
+}
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+
+/**
+ * Format currency with USD symbol
+ */
+const formatCurrency = (amount: number): string => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount);
+};
+
+/**
+ * Format date as MMM DD, YYYY
+ */
+const formatDate = (dateString: string): string => {
+  const date = new Date(dateString + 'T00:00:00');
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+/**
+ * Truncate text if longer than maxLength
+ */
+const truncateText = (text: string | null, maxLength: number): string => {
+  if (!text) return '-';
+  return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+};
+
+interface TransactionRowProps {
+  transaction: Transaction;
+  onEdit: (transaction: Transaction) => void;
+  onDelete: (transaction: Transaction) => void;
+}
+
+const TransactionRow: React.FC<TransactionRowProps> = ({
+  transaction,
+  onEdit,
+  onDelete,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const isIncome = transaction.type === 'INCOME';
+
+  return (
+    <>
+      <TableRow
+        hover
+        sx={{ cursor: 'pointer' }}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <TableCell padding="checkbox">
+          <IconButton
+            size="small"
+            aria-label={expanded ? 'Collapse details' : 'Expand details'}
+          >
+            {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </TableCell>
+        <TableCell>{formatDate(transaction.date)}</TableCell>
+        <TableCell>
+          <Chip
+            size="small"
+            label={transaction.type}
+            color={isIncome ? 'success' : 'error'}
+            variant="outlined"
+          />
+        </TableCell>
+        <TableCell>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Icon sx={{ color: transaction.category.color, fontSize: 20 }}>
+              {transaction.category.icon}
+            </Icon>
+            <Typography variant="body2">{transaction.category.name}</Typography>
+          </Box>
+        </TableCell>
+        <TableCell>
+          <Tooltip title={transaction.description || ''} arrow>
+            <Typography variant="body2">
+              {truncateText(transaction.description, 50)}
+            </Typography>
+          </Tooltip>
+        </TableCell>
+        <TableCell align="right">
+          <Typography
+            variant="body2"
+            fontWeight={600}
+            color={isIncome ? 'success.main' : 'error.main'}
+          >
+            {isIncome ? '+' : '-'}{formatCurrency(transaction.amount)}
+          </Typography>
+        </TableCell>
+        <TableCell align="right">
+          <Tooltip title="Edit transaction">
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(transaction);
+              }}
+              aria-label="Edit transaction"
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Delete transaction">
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(transaction);
+              }}
+              aria-label="Delete transaction"
+              color="error"
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </TableCell>
+      </TableRow>
+
+      {/* Expanded details row */}
+      <TableRow>
+        <TableCell colSpan={7} sx={{ py: 0, borderBottom: expanded ? undefined : 'none' }}>
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <Box sx={{ py: 2, px: 3, bgcolor: 'grey.50' }}>
+              <Typography variant="subtitle2" gutterBottom>
+                Transaction Details
+              </Typography>
+              <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Description
+                  </Typography>
+                  <Typography variant="body2">
+                    {transaction.description || '-'}
+                  </Typography>
+                </Box>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Notes
+                  </Typography>
+                  <Typography variant="body2">{transaction.notes || '-'}</Typography>
+                </Box>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Created
+                  </Typography>
+                  <Typography variant="body2">
+                    {new Date(transaction.createdAt).toLocaleString()}
+                  </Typography>
+                </Box>
+                <Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Last Updated
+                  </Typography>
+                  <Typography variant="body2">
+                    {new Date(transaction.updatedAt).toLocaleString()}
+                  </Typography>
+                </Box>
+              </Box>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  );
+};
+
+const LoadingSkeleton: React.FC = () => (
+  <>
+    {[...Array(5)].map((_, index) => (
+      <TableRow key={index}>
+        <TableCell padding="checkbox">
+          <Skeleton variant="circular" width={24} height={24} />
+        </TableCell>
+        <TableCell>
+          <Skeleton variant="text" width={80} />
+        </TableCell>
+        <TableCell>
+          <Skeleton variant="rounded" width={70} height={24} />
+        </TableCell>
+        <TableCell>
+          <Skeleton variant="text" width={100} />
+        </TableCell>
+        <TableCell>
+          <Skeleton variant="text" width={150} />
+        </TableCell>
+        <TableCell align="right">
+          <Skeleton variant="text" width={80} />
+        </TableCell>
+        <TableCell align="right">
+          <Skeleton variant="circular" width={32} height={32} />
+        </TableCell>
+      </TableRow>
+    ))}
+  </>
+);
+
+/**
+ * TransactionList - Table/list of transactions with actions
+ * Supports sorting, pagination, and expandable rows
+ */
+const TransactionList: React.FC<TransactionListProps> = ({
+  transactions,
+  loading = false,
+  page,
+  pageSize,
+  totalElements,
+  sortField,
+  sortDirection,
+  onPageChange,
+  onPageSizeChange,
+  onSortChange,
+  onEdit,
+  onDelete,
+}) => {
+  const handleSort = (field: SortField) => {
+    const isAsc = sortField === field && sortDirection === 'asc';
+    onSortChange(field, isAsc ? 'desc' : 'asc');
+  };
+
+  const handleChangePage = (_: unknown, newPage: number) => {
+    onPageChange(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onPageSizeChange(parseInt(event.target.value, 10));
+    onPageChange(0);
+  };
+
+  const createSortHandler = (field: SortField) => () => {
+    handleSort(field);
+  };
+
+  // Calculate display range
+  const startItem = page * pageSize + 1;
+  const endItem = Math.min((page + 1) * pageSize, totalElements);
+
+  return (
+    <Paper>
+      <TableContainer>
+        <Table aria-label="Transactions table">
+          <TableHead>
+            <TableRow>
+              <TableCell padding="checkbox" sx={{ width: 48 }} />
+              <TableCell sortDirection={sortField === 'date' ? sortDirection : false}>
+                <TableSortLabel
+                  active={sortField === 'date'}
+                  direction={sortField === 'date' ? sortDirection : 'asc'}
+                  onClick={createSortHandler('date')}
+                >
+                  Date
+                </TableSortLabel>
+              </TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell sortDirection={sortField === 'category' ? sortDirection : false}>
+                <TableSortLabel
+                  active={sortField === 'category'}
+                  direction={sortField === 'category' ? sortDirection : 'asc'}
+                  onClick={createSortHandler('category')}
+                >
+                  Category
+                </TableSortLabel>
+              </TableCell>
+              <TableCell>Description</TableCell>
+              <TableCell
+                align="right"
+                sortDirection={sortField === 'amount' ? sortDirection : false}
+              >
+                <TableSortLabel
+                  active={sortField === 'amount'}
+                  direction={sortField === 'amount' ? sortDirection : 'asc'}
+                  onClick={createSortHandler('amount')}
+                >
+                  Amount
+                </TableSortLabel>
+              </TableCell>
+              <TableCell align="right" sx={{ width: 100 }}>
+                Actions
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
+              <LoadingSkeleton />
+            ) : transactions.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} align="center" sx={{ py: 8 }}>
+                  <Typography variant="h6" color="text.secondary" gutterBottom>
+                    No transactions yet
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Create your first transaction to get started.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              transactions.map((transaction) => (
+                <TransactionRow
+                  key={transaction.id}
+                  transaction={transaction}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                />
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Pagination */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: 2,
+          borderTop: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          {totalElements > 0
+            ? `Showing ${startItem}-${endItem} of ${totalElements} transactions`
+            : 'No transactions'}
+        </Typography>
+        <TablePagination
+          component="div"
+          count={totalElements}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={pageSize}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+          labelRowsPerPage="Per page:"
+        />
+      </Box>
+    </Paper>
+  );
+};
+
+export default TransactionList;

--- a/frontend/src/components/transactions/TransactionSearch.tsx
+++ b/frontend/src/components/transactions/TransactionSearch.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  TextField,
+  InputAdornment,
+  IconButton,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import ClearIcon from '@mui/icons-material/Clear';
+
+interface TransactionSearchProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  debounceMs?: number;
+}
+
+/**
+ * TransactionSearch - Search input with debounce
+ * Debounces input to prevent excessive API calls
+ */
+const TransactionSearch: React.FC<TransactionSearchProps> = ({
+  value,
+  onChange,
+  placeholder = 'Search transactions...',
+  debounceMs = 300,
+}) => {
+  const [inputValue, setInputValue] = useState(value);
+
+  // Sync internal state with external value
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  // Debounce the onChange callback
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (inputValue !== value) {
+        // Only trigger search if minimum 2 characters or empty
+        if (inputValue.length >= 2 || inputValue.length === 0) {
+          onChange(inputValue);
+        }
+      }
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+  }, [inputValue, value, onChange, debounceMs]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value);
+  };
+
+  const handleClear = useCallback(() => {
+    setInputValue('');
+    onChange('');
+  }, [onChange]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      handleClear();
+    }
+  };
+
+  return (
+    <TextField
+      fullWidth
+      size="small"
+      placeholder={placeholder}
+      value={inputValue}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+      aria-label="Search transactions"
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon color="action" />
+          </InputAdornment>
+        ),
+        endAdornment: inputValue ? (
+          <InputAdornment position="end">
+            <IconButton
+              size="small"
+              onClick={handleClear}
+              aria-label="Clear search"
+            >
+              <ClearIcon fontSize="small" />
+            </IconButton>
+          </InputAdornment>
+        ) : null,
+      }}
+      sx={{
+        '& .MuiOutlinedInput-root': {
+          bgcolor: 'background.paper',
+        },
+      }}
+    />
+  );
+};
+
+export default TransactionSearch;

--- a/frontend/src/components/transactions/TransactionSummary.tsx
+++ b/frontend/src/components/transactions/TransactionSummary.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  Skeleton,
+} from '@mui/material';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
+import AccountBalanceIcon from '@mui/icons-material/AccountBalance';
+import type { TransactionListSummary } from '@/types';
+
+interface TransactionSummaryProps {
+  summary: TransactionListSummary | null;
+  loading?: boolean;
+}
+
+/**
+ * Format currency with USD symbol
+ */
+const formatCurrency = (amount: number): string => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount);
+};
+
+interface SummaryCardProps {
+  title: string;
+  amount: number;
+  icon: React.ReactNode;
+  color: string;
+  loading?: boolean;
+}
+
+const SummaryCard: React.FC<SummaryCardProps> = ({
+  title,
+  amount,
+  icon,
+  color,
+  loading = false,
+}) => (
+  <Card sx={{ height: '100%' }}>
+    <CardContent>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 40,
+            height: 40,
+            borderRadius: 2,
+            bgcolor: `${color}15`,
+            color: color,
+            mr: 2,
+          }}
+        >
+          {icon}
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          {title}
+        </Typography>
+      </Box>
+      {loading ? (
+        <Skeleton variant="text" width="60%" height={40} />
+      ) : (
+        <Typography
+          variant="h5"
+          component="div"
+          sx={{ fontWeight: 600, color: color }}
+        >
+          {formatCurrency(amount)}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+/**
+ * TransactionSummary - Summary cards showing income, expenses, and balance
+ */
+const TransactionSummary: React.FC<TransactionSummaryProps> = ({
+  summary,
+  loading = false,
+}) => {
+  const income = summary?.totalIncome ?? 0;
+  const expenses = summary?.totalExpenses ?? 0;
+  const balance = summary?.netBalance ?? 0;
+
+  const balanceColor = balance >= 0 ? '#4caf50' : '#f44336';
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12} sm={4}>
+        <SummaryCard
+          title="Total Income"
+          amount={income}
+          icon={<TrendingUpIcon />}
+          color="#4caf50"
+          loading={loading}
+        />
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        <SummaryCard
+          title="Total Expenses"
+          amount={expenses}
+          icon={<TrendingDownIcon />}
+          color="#f44336"
+          loading={loading}
+        />
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        <SummaryCard
+          title="Net Balance"
+          amount={balance}
+          icon={<AccountBalanceIcon />}
+          color={balanceColor}
+          loading={loading}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default TransactionSummary;

--- a/frontend/src/components/transactions/index.ts
+++ b/frontend/src/components/transactions/index.ts
@@ -1,0 +1,7 @@
+export { default as TransactionList } from './TransactionList';
+export { default as TransactionForm } from './TransactionForm';
+export { default as TransactionSummary } from './TransactionSummary';
+export { default as TransactionFilter } from './TransactionFilter';
+export { default as TransactionSearch } from './TransactionSearch';
+export { default as DeleteConfirmDialog } from './DeleteConfirmDialog';
+export { default as CategorySelect } from './CategorySelect';

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -14,6 +14,11 @@ export const ROUTES = {
   SETTINGS: '/settings',
   SESSIONS: '/settings/sessions',
 
+  // Transaction routes
+  TRANSACTIONS: '/transactions',
+  TRANSACTIONS_NEW: '/transactions/new',
+  TRANSACTIONS_EDIT: '/transactions/:id/edit',
+
   // Root
   HOME: '/',
 } as const;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,9 +10,15 @@ import {
   MenuItem,
   Avatar,
   Button,
+  Card,
+  CardContent,
+  CardActions,
+  Grid,
 } from '@mui/material';
 import { AccountCircle, Logout, Settings } from '@mui/icons-material';
 import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/context';
 import { ROUTES } from '@/constants';
@@ -111,17 +117,92 @@ const DashboardPage: React.FC = () => {
 
       {/* Main Content */}
       <Container maxWidth="lg" sx={{ flexGrow: 1, py: 4 }}>
-        <Box sx={{ textAlign: 'center', py: 8 }}>
+        <Box sx={{ mb: 4 }}>
           <Typography variant="h4" component="h1" gutterBottom>
             Welcome{user?.firstName ? `, ${user.firstName}` : ''}!
           </Typography>
-          <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+          <Typography variant="body1" color="text.secondary">
             Your personal finance dashboard. Start tracking your income, expenses, and budgets.
           </Typography>
-          <Button variant="contained" size="large" disabled>
-            Coming Soon: Add Transaction
-          </Button>
         </Box>
+
+        {/* Quick Actions */}
+        <Grid container spacing={3}>
+          {/* Transactions Card */}
+          <Grid item xs={12} sm={6} md={4}>
+            <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+              <CardContent sx={{ flexGrow: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                  <ReceiptLongIcon color="primary" sx={{ fontSize: 40, mr: 2 }} />
+                  <Typography variant="h6" component="h2">
+                    Transactions
+                  </Typography>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                  View and manage all your income and expense transactions. Filter by date, category, or amount.
+                </Typography>
+              </CardContent>
+              <CardActions sx={{ p: 2, pt: 0 }}>
+                <Button
+                  variant="contained"
+                  onClick={() => navigate(ROUTES.TRANSACTIONS)}
+                  fullWidth
+                >
+                  View Transactions
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+
+          {/* Add Transaction Card */}
+          <Grid item xs={12} sm={6} md={4}>
+            <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+              <CardContent sx={{ flexGrow: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                  <AddCircleOutlineIcon color="success" sx={{ fontSize: 40, mr: 2 }} />
+                  <Typography variant="h6" component="h2">
+                    Add Transaction
+                  </Typography>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                  Record a new income or expense transaction to keep your finances up to date.
+                </Typography>
+              </CardContent>
+              <CardActions sx={{ p: 2, pt: 0 }}>
+                <Button
+                  variant="outlined"
+                  color="success"
+                  onClick={() => navigate(ROUTES.TRANSACTIONS_NEW)}
+                  fullWidth
+                >
+                  Add New
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+
+          {/* Budgets Card (Coming Soon) */}
+          <Grid item xs={12} sm={6} md={4}>
+            <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column', opacity: 0.7 }}>
+              <CardContent sx={{ flexGrow: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                  <AccountBalanceWalletIcon color="secondary" sx={{ fontSize: 40, mr: 2 }} />
+                  <Typography variant="h6" component="h2">
+                    Budgets
+                  </Typography>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                  Set monthly budgets for different categories and track your spending progress.
+                </Typography>
+              </CardContent>
+              <CardActions sx={{ p: 2, pt: 0 }}>
+                <Button variant="outlined" disabled fullWidth>
+                  Coming Soon
+                </Button>
+              </CardActions>
+            </Card>
+          </Grid>
+        </Grid>
       </Container>
     </Box>
   );

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
+export * from './transactions';
 export { default as DashboardPage } from './DashboardPage';
 export { default as SettingsPage } from './SettingsPage';

--- a/frontend/src/pages/transactions/CreateTransactionPage.tsx
+++ b/frontend/src/pages/transactions/CreateTransactionPage.tsx
@@ -1,0 +1,222 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Container,
+  Typography,
+  Paper,
+  Breadcrumbs,
+  Link,
+  AppBar,
+  Toolbar,
+  IconButton,
+  Menu,
+  MenuItem,
+  Avatar,
+  Snackbar,
+  Alert,
+} from '@mui/material';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import { AccountCircle, Logout, Settings } from '@mui/icons-material';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import { useAuth } from '@/context';
+import { ROUTES } from '@/constants';
+import { transactionApi, getErrorMessage } from '@/api';
+import type { CreateTransactionRequest } from '@/types';
+import { TransactionForm } from '@/components/transactions';
+
+/**
+ * CreateTransactionPage - Form page for new transaction
+ */
+const CreateTransactionPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({ open: false, message: '', severity: 'success' });
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSettings = () => {
+    handleMenuClose();
+    navigate(ROUTES.SETTINGS);
+  };
+
+  const handleLogout = async () => {
+    handleMenuClose();
+    await logout();
+  };
+
+  const handleDashboard = () => {
+    navigate(ROUTES.DASHBOARD);
+  };
+
+  const handleSubmit = async (data: CreateTransactionRequest) => {
+    setLoading(true);
+    setError(null);
+    try {
+      await transactionApi.createTransaction(data);
+      setSnackbar({
+        open: true,
+        message: 'Transaction created successfully',
+        severity: 'success',
+      });
+      // Navigate back to transactions list after short delay
+      setTimeout(() => {
+        navigate(ROUTES.TRANSACTIONS);
+      }, 1000);
+    } catch (err) {
+      setError(getErrorMessage(err));
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    navigate(ROUTES.TRANSACTIONS);
+  };
+
+  const handleCloseSnackbar = () => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
+
+  const userInitials = user
+    ? `${user.firstName?.[0] || ''}${user.lastName?.[0] || ''}`.toUpperCase() ||
+      user.email[0].toUpperCase()
+    : '';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      {/* App Bar */}
+      <AppBar position="static" color="default" elevation={1}>
+        <Toolbar>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexGrow: 1,
+              cursor: 'pointer',
+            }}
+            onClick={handleDashboard}
+          >
+            <AccountBalanceWalletIcon sx={{ mr: 1, color: 'primary.main' }} />
+            <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
+              Personal Finance
+            </Typography>
+          </Box>
+
+          {/* User Menu */}
+          <IconButton
+            size="large"
+            aria-label="Account menu"
+            aria-controls="menu-appbar"
+            aria-haspopup="true"
+            onClick={handleMenuOpen}
+            color="inherit"
+          >
+            {userInitials ? (
+              <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main' }}>
+                {userInitials}
+              </Avatar>
+            ) : (
+              <AccountCircle />
+            )}
+          </IconButton>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={Boolean(anchorEl)}
+            onClose={handleMenuClose}
+          >
+            <MenuItem disabled sx={{ opacity: 1 }}>
+              <Typography variant="body2" color="text.secondary">
+                {user?.email}
+              </Typography>
+            </MenuItem>
+            <MenuItem onClick={handleSettings}>
+              <Settings sx={{ mr: 1, fontSize: 20 }} />
+              Settings
+            </MenuItem>
+            <MenuItem onClick={handleLogout}>
+              <Logout sx={{ mr: 1, fontSize: 20 }} />
+              Logout
+            </MenuItem>
+          </Menu>
+        </Toolbar>
+      </AppBar>
+
+      {/* Main Content */}
+      <Container maxWidth="md" sx={{ flexGrow: 1, py: 4 }}>
+        {/* Breadcrumbs */}
+        <Breadcrumbs
+          separator={<NavigateNextIcon fontSize="small" />}
+          sx={{ mb: 3 }}
+        >
+          <Link
+            component="button"
+            variant="body1"
+            onClick={() => navigate(ROUTES.TRANSACTIONS)}
+            underline="hover"
+            color="inherit"
+          >
+            Transactions
+          </Link>
+          <Typography color="text.primary">New Transaction</Typography>
+        </Breadcrumbs>
+
+        {/* Page Header */}
+        <Typography variant="h4" component="h1" fontWeight={600} sx={{ mb: 4 }}>
+          Create Transaction
+        </Typography>
+
+        {/* Form Card */}
+        <Paper sx={{ p: 4 }}>
+          <TransactionForm
+            onSubmit={handleSubmit}
+            onCancel={handleCancel}
+            loading={loading}
+            error={error}
+          />
+        </Paper>
+      </Container>
+
+      {/* Snackbar for success message */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbar.severity}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default CreateTransactionPage;

--- a/frontend/src/pages/transactions/EditTransactionPage.tsx
+++ b/frontend/src/pages/transactions/EditTransactionPage.tsx
@@ -1,0 +1,268 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  Box,
+  Container,
+  Typography,
+  Paper,
+  Breadcrumbs,
+  Link,
+  AppBar,
+  Toolbar,
+  IconButton,
+  Menu,
+  MenuItem,
+  Avatar,
+  Snackbar,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import { AccountCircle, Logout, Settings } from '@mui/icons-material';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import { useAuth } from '@/context';
+import { ROUTES } from '@/constants';
+import { transactionApi, getErrorMessage } from '@/api';
+import type { Transaction, UpdateTransactionRequest } from '@/types';
+import { TransactionForm } from '@/components/transactions';
+
+/**
+ * EditTransactionPage - Form page for editing transaction
+ */
+const EditTransactionPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const { user, logout } = useAuth();
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [transaction, setTransaction] = useState<Transaction | null>(null);
+  const [fetchLoading, setFetchLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({ open: false, message: '', severity: 'success' });
+
+  // Fetch transaction on mount
+  useEffect(() => {
+    const fetchTransaction = async () => {
+      if (!id) {
+        setFetchError('Transaction ID is required');
+        setFetchLoading(false);
+        return;
+      }
+
+      try {
+        const data = await transactionApi.getTransaction(id);
+        setTransaction(data);
+      } catch (err) {
+        setFetchError(getErrorMessage(err));
+      } finally {
+        setFetchLoading(false);
+      }
+    };
+
+    fetchTransaction();
+  }, [id]);
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSettings = () => {
+    handleMenuClose();
+    navigate(ROUTES.SETTINGS);
+  };
+
+  const handleLogout = async () => {
+    handleMenuClose();
+    await logout();
+  };
+
+  const handleDashboard = () => {
+    navigate(ROUTES.DASHBOARD);
+  };
+
+  const handleSubmit = async (data: UpdateTransactionRequest) => {
+    if (!id) return;
+
+    setSubmitLoading(true);
+    setSubmitError(null);
+    try {
+      await transactionApi.updateTransaction(id, data);
+      setSnackbar({
+        open: true,
+        message: 'Transaction updated successfully',
+        severity: 'success',
+      });
+      // Navigate back to transactions list after short delay
+      setTimeout(() => {
+        navigate(ROUTES.TRANSACTIONS);
+      }, 1000);
+    } catch (err) {
+      setSubmitError(getErrorMessage(err));
+      setSubmitLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    navigate(ROUTES.TRANSACTIONS);
+  };
+
+  const handleCloseSnackbar = () => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
+
+  const userInitials = user
+    ? `${user.firstName?.[0] || ''}${user.lastName?.[0] || ''}`.toUpperCase() ||
+      user.email[0].toUpperCase()
+    : '';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      {/* App Bar */}
+      <AppBar position="static" color="default" elevation={1}>
+        <Toolbar>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexGrow: 1,
+              cursor: 'pointer',
+            }}
+            onClick={handleDashboard}
+          >
+            <AccountBalanceWalletIcon sx={{ mr: 1, color: 'primary.main' }} />
+            <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
+              Personal Finance
+            </Typography>
+          </Box>
+
+          {/* User Menu */}
+          <IconButton
+            size="large"
+            aria-label="Account menu"
+            aria-controls="menu-appbar"
+            aria-haspopup="true"
+            onClick={handleMenuOpen}
+            color="inherit"
+          >
+            {userInitials ? (
+              <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main' }}>
+                {userInitials}
+              </Avatar>
+            ) : (
+              <AccountCircle />
+            )}
+          </IconButton>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={Boolean(anchorEl)}
+            onClose={handleMenuClose}
+          >
+            <MenuItem disabled sx={{ opacity: 1 }}>
+              <Typography variant="body2" color="text.secondary">
+                {user?.email}
+              </Typography>
+            </MenuItem>
+            <MenuItem onClick={handleSettings}>
+              <Settings sx={{ mr: 1, fontSize: 20 }} />
+              Settings
+            </MenuItem>
+            <MenuItem onClick={handleLogout}>
+              <Logout sx={{ mr: 1, fontSize: 20 }} />
+              Logout
+            </MenuItem>
+          </Menu>
+        </Toolbar>
+      </AppBar>
+
+      {/* Main Content */}
+      <Container maxWidth="md" sx={{ flexGrow: 1, py: 4 }}>
+        {/* Breadcrumbs */}
+        <Breadcrumbs
+          separator={<NavigateNextIcon fontSize="small" />}
+          sx={{ mb: 3 }}
+        >
+          <Link
+            component="button"
+            variant="body1"
+            onClick={() => navigate(ROUTES.TRANSACTIONS)}
+            underline="hover"
+            color="inherit"
+          >
+            Transactions
+          </Link>
+          <Typography color="text.primary">Edit Transaction</Typography>
+        </Breadcrumbs>
+
+        {/* Page Header */}
+        <Typography variant="h4" component="h1" fontWeight={600} sx={{ mb: 4 }}>
+          Edit Transaction
+        </Typography>
+
+        {/* Loading State */}
+        {fetchLoading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {/* Error State */}
+        {fetchError && (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {fetchError}
+          </Alert>
+        )}
+
+        {/* Form Card */}
+        {!fetchLoading && !fetchError && transaction && (
+          <Paper sx={{ p: 4 }}>
+            <TransactionForm
+              transaction={transaction}
+              onSubmit={handleSubmit}
+              onCancel={handleCancel}
+              loading={submitLoading}
+              error={submitError}
+            />
+          </Paper>
+        )}
+      </Container>
+
+      {/* Snackbar for success message */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbar.severity}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default EditTransactionPage;

--- a/frontend/src/pages/transactions/TransactionsPage.test.tsx
+++ b/frontend/src/pages/transactions/TransactionsPage.test.tsx
@@ -1,0 +1,533 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { ThemeProvider, createTheme } from '@mui/material';
+import TransactionsPage from './TransactionsPage';
+import { AuthProvider } from '@/context';
+import type { TransactionListResponse } from '@/types';
+
+const theme = createTheme();
+
+// Mock the API module
+vi.mock('@/api', () => ({
+  transactionApi: {
+    getTransactions: vi.fn(),
+    deleteTransaction: vi.fn(),
+    createTransaction: vi.fn(),
+    updateTransaction: vi.fn(),
+  },
+  categoryApi: {
+    getCategories: vi.fn().mockResolvedValue({
+      income: [
+        { id: 'cat-salary', name: 'Salary', type: 'INCOME', icon: 'payments', color: '#4CAF50' },
+      ],
+      expense: [
+        { id: 'cat-food', name: 'Food & Dining', type: 'EXPENSE', icon: 'restaurant', color: '#F44336' },
+      ],
+    }),
+  },
+  getErrorMessage: vi.fn((err) => err?.response?.data?.message || err?.message || 'An error occurred'),
+}));
+
+// Mock the AuthContext
+vi.mock('@/context', async () => {
+  const actual = await vi.importActual('@/context');
+  return {
+    ...actual,
+    useAuth: vi.fn(() => ({
+      user: {
+        id: 'user-1',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      logout: vi.fn(),
+    })),
+    AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+const mockTransactionListResponse: TransactionListResponse = {
+  content: [
+    {
+      id: 'tx-1',
+      amount: 150.0,
+      type: 'EXPENSE',
+      category: {
+        id: 'cat-food',
+        name: 'Food & Dining',
+        type: 'EXPENSE',
+        icon: 'restaurant',
+        color: '#F44336',
+      },
+      date: '2026-01-20',
+      description: 'Grocery shopping',
+      notes: null,
+      createdAt: '2026-01-20T14:30:00Z',
+      updatedAt: '2026-01-20T14:30:00Z',
+    },
+    {
+      id: 'tx-2',
+      amount: 5000.0,
+      type: 'INCOME',
+      category: {
+        id: 'cat-salary',
+        name: 'Salary',
+        type: 'INCOME',
+        icon: 'payments',
+        color: '#4CAF50',
+      },
+      date: '2026-01-15',
+      description: 'Monthly salary',
+      notes: null,
+      createdAt: '2026-01-15T09:00:00Z',
+      updatedAt: '2026-01-15T09:00:00Z',
+    },
+  ],
+  page: 0,
+  size: 20,
+  totalElements: 2,
+  totalPages: 1,
+  first: true,
+  last: true,
+  summary: {
+    totalIncome: 5000.0,
+    totalExpenses: 150.0,
+    netBalance: 4850.0,
+  },
+};
+
+const emptyTransactionListResponse: TransactionListResponse = {
+  content: [],
+  page: 0,
+  size: 20,
+  totalElements: 0,
+  totalPages: 0,
+  first: true,
+  last: true,
+  summary: {
+    totalIncome: 0,
+    totalExpenses: 0,
+    netBalance: 0,
+  },
+};
+
+const renderTransactionsPage = (initialRoute = '/transactions') => {
+  return render(
+    <ThemeProvider theme={theme}>
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <Routes>
+          <Route path="/transactions" element={<TransactionsPage />} />
+          <Route path="/transactions/new" element={<div>Create Transaction Page</div>} />
+          <Route path="/transactions/:id/edit" element={<div>Edit Transaction Page</div>} />
+          <Route path="/dashboard" element={<div>Dashboard</div>} />
+          <Route path="/settings" element={<div>Settings</div>} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+};
+
+describe('TransactionsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Initial Rendering', () => {
+    it('should render page title', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      expect(screen.getByText('Transactions')).toBeInTheDocument();
+    });
+
+    it('should render Add Transaction button', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      expect(screen.getByRole('button', { name: /add transaction/i })).toBeInTheDocument();
+    });
+
+    it('should fetch transactions on mount', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(transactionApi.getTransactions).toHaveBeenCalled();
+      });
+    });
+
+    it('should display transactions after loading', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
+        expect(screen.getByText('Monthly salary')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Summary Display', () => {
+    it('should display transaction summary', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        // Summary component should show totals
+        expect(screen.getByText('$5,000.00')).toBeInTheDocument();
+        expect(screen.getByText('$150.00')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Empty State', () => {
+    it('should show empty message when no transactions', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        emptyTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText(/no transactions yet/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should display error message on fetch failure', async () => {
+      const { transactionApi, getErrorMessage } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Network error')
+      );
+      (getErrorMessage as ReturnType<typeof vi.fn>).mockReturnValue('Failed to load transactions');
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('Failed to load transactions');
+      });
+    });
+  });
+
+  describe('Navigation', () => {
+    it('should navigate to create page when clicking Add Transaction', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add transaction/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /add transaction/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Create Transaction Page')).toBeInTheDocument();
+      });
+    });
+
+    it('should navigate to edit page when clicking edit button', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
+      });
+
+      const editButtons = screen.getAllByRole('button', { name: /edit transaction/i });
+      await user.click(editButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit Transaction Page')).toBeInTheDocument();
+      });
+    });
+
+    it('should navigate to dashboard when clicking logo', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Personal Finance')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Personal Finance'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Dashboard')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Delete Transaction', () => {
+    it('should show delete confirmation dialog', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete transaction/i });
+      await user.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should delete transaction on confirm', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+      (transactionApi.deleteTransaction as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete transaction/i });
+      await user.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      await waitFor(() => {
+        expect(transactionApi.deleteTransaction).toHaveBeenCalledWith('tx-1');
+      });
+    });
+
+    it('should close dialog on cancel', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete transaction/i });
+      await user.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/are you sure/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show success snackbar after delete', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+      (transactionApi.deleteTransaction as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Grocery shopping')).toBeInTheDocument();
+      });
+
+      const deleteButtons = screen.getAllByRole('button', { name: /delete transaction/i });
+      await user.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/deleted successfully/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Filtering', () => {
+    it('should fetch with filter parameters', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage('/transactions?type=EXPENSE');
+
+      await waitFor(() => {
+        expect(transactionApi.getTransactions).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'EXPENSE',
+          })
+        );
+      });
+    });
+
+    it('should persist filters in URL', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage('/transactions?startDate=2026-01-01&endDate=2026-01-31');
+
+      await waitFor(() => {
+        expect(transactionApi.getTransactions).toHaveBeenCalledWith(
+          expect.objectContaining({
+            startDate: '2026-01-01',
+            endDate: '2026-01-31',
+          })
+        );
+      });
+    });
+  });
+
+  describe('Pagination', () => {
+    it('should fetch with pagination parameters from URL', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage('/transactions?page=2&size=50');
+
+      await waitFor(() => {
+        expect(transactionApi.getTransactions).toHaveBeenCalledWith(
+          expect.objectContaining({
+            page: 2,
+            size: 50,
+          })
+        );
+      });
+    });
+  });
+
+  describe('Search', () => {
+    it('should fetch with search parameter from URL', async () => {
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage('/transactions?search=grocery');
+
+      await waitFor(() => {
+        expect(transactionApi.getTransactions).toHaveBeenCalledWith(
+          expect.objectContaining({
+            search: 'grocery',
+          })
+        );
+      });
+    });
+  });
+
+  describe('User Menu', () => {
+    it('should show user email in menu', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Transactions')).toBeInTheDocument();
+      });
+
+      // Find and click user avatar/menu button
+      const menuButton = screen.getByRole('button', { name: /account menu/i });
+      await user.click(menuButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('test@example.com')).toBeInTheDocument();
+      });
+    });
+
+    it('should navigate to settings from menu', async () => {
+      const user = userEvent.setup();
+      const { transactionApi } = await import('@/api');
+      (transactionApi.getTransactions as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockTransactionListResponse
+      );
+
+      renderTransactionsPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('Transactions')).toBeInTheDocument();
+      });
+
+      const menuButton = screen.getByRole('button', { name: /account menu/i });
+      await user.click(menuButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('menuitem', { name: /settings/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/pages/transactions/TransactionsPage.tsx
+++ b/frontend/src/pages/transactions/TransactionsPage.tsx
@@ -1,0 +1,442 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  Box,
+  Container,
+  Typography,
+  Button,
+  Snackbar,
+  Alert,
+  AppBar,
+  Toolbar,
+  IconButton,
+  Menu,
+  MenuItem,
+  Avatar,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import { AccountCircle, Logout, Settings } from '@mui/icons-material';
+import { useAuth } from '@/context';
+import { ROUTES } from '@/constants';
+import { transactionApi, getErrorMessage } from '@/api';
+import type {
+  Transaction,
+  TransactionFilter as TransactionFilterType,
+  TransactionListResponse,
+  SortField,
+  SortDirection,
+} from '@/types';
+import {
+  TransactionList,
+  TransactionSummary,
+  TransactionFilter,
+  TransactionSearch,
+  DeleteConfirmDialog,
+} from '@/components/transactions';
+
+const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_SORT_FIELD: SortField = 'date';
+const DEFAULT_SORT_DIRECTION: SortDirection = 'desc';
+
+/**
+ * Parse URL search params into filter object
+ */
+const parseSearchParams = (params: URLSearchParams): TransactionFilterType => {
+  const filter: TransactionFilterType = {};
+
+  const startDate = params.get('startDate');
+  const endDate = params.get('endDate');
+  const type = params.get('type');
+  const categoryIds = params.get('categoryIds');
+  const minAmount = params.get('minAmount');
+  const maxAmount = params.get('maxAmount');
+  const search = params.get('search');
+  const page = params.get('page');
+  const size = params.get('size');
+  const sort = params.get('sort');
+
+  if (startDate) filter.startDate = startDate;
+  if (endDate) filter.endDate = endDate;
+  if (type === 'INCOME' || type === 'EXPENSE') filter.type = type;
+  if (categoryIds) filter.categoryIds = categoryIds.split(',');
+  if (minAmount) filter.minAmount = parseFloat(minAmount);
+  if (maxAmount) filter.maxAmount = parseFloat(maxAmount);
+  if (search) filter.search = search;
+  if (page) filter.page = parseInt(page, 10);
+  if (size) filter.size = parseInt(size, 10);
+  if (sort) filter.sort = sort;
+
+  return filter;
+};
+
+/**
+ * Build URL search params from filter object
+ */
+const buildSearchParams = (filter: TransactionFilterType): URLSearchParams => {
+  const params = new URLSearchParams();
+
+  if (filter.startDate) params.set('startDate', filter.startDate);
+  if (filter.endDate) params.set('endDate', filter.endDate);
+  if (filter.type) params.set('type', filter.type);
+  if (filter.categoryIds && filter.categoryIds.length > 0) {
+    params.set('categoryIds', filter.categoryIds.join(','));
+  }
+  if (filter.minAmount !== undefined) params.set('minAmount', filter.minAmount.toString());
+  if (filter.maxAmount !== undefined) params.set('maxAmount', filter.maxAmount.toString());
+  if (filter.search) params.set('search', filter.search);
+  if (filter.page !== undefined && filter.page !== 0) {
+    params.set('page', filter.page.toString());
+  }
+  if (filter.size !== undefined && filter.size !== DEFAULT_PAGE_SIZE) {
+    params.set('size', filter.size.toString());
+  }
+  if (filter.sort && filter.sort !== `${DEFAULT_SORT_FIELD},${DEFAULT_SORT_DIRECTION}`) {
+    params.set('sort', filter.sort);
+  }
+
+  return params;
+};
+
+/**
+ * TransactionsPage - Main page with list, filters, summary
+ */
+const TransactionsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { user, logout } = useAuth();
+
+  // User menu state
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  // Data state
+  const [response, setResponse] = useState<TransactionListResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filter state from URL
+  const [filter, setFilter] = useState<TransactionFilterType>(() =>
+    parseSearchParams(searchParams)
+  );
+
+  // Sort state
+  const [sortField, setSortField] = useState<SortField>(() => {
+    const sort = filter.sort || `${DEFAULT_SORT_FIELD},${DEFAULT_SORT_DIRECTION}`;
+    return sort.split(',')[0] as SortField;
+  });
+  const [sortDirection, setSortDirection] = useState<SortDirection>(() => {
+    const sort = filter.sort || `${DEFAULT_SORT_FIELD},${DEFAULT_SORT_DIRECTION}`;
+    return sort.split(',')[1] as SortDirection;
+  });
+
+  // Delete dialog state
+  const [deleteTarget, setDeleteTarget] = useState<Transaction | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  // Snackbar state
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error';
+  }>({ open: false, message: '', severity: 'success' });
+
+  // Fetch transactions
+  const fetchTransactions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await transactionApi.getTransactions(filter);
+      setResponse(data);
+    } catch (err) {
+      setError(getErrorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [filter]);
+
+  useEffect(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
+
+  // Sync filter to URL
+  useEffect(() => {
+    const params = buildSearchParams(filter);
+    setSearchParams(params, { replace: true });
+  }, [filter, setSearchParams]);
+
+  // User menu handlers
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSettings = () => {
+    handleMenuClose();
+    navigate(ROUTES.SETTINGS);
+  };
+
+  const handleLogout = async () => {
+    handleMenuClose();
+    await logout();
+  };
+
+  const handleDashboard = () => {
+    navigate(ROUTES.DASHBOARD);
+  };
+
+  // Filter handlers
+  const handleFilterChange = (newFilter: TransactionFilterType) => {
+    setFilter({ ...newFilter, page: 0 }); // Reset to first page on filter change
+  };
+
+  const handleClearFilters = () => {
+    setFilter({
+      page: 0,
+      size: filter.size,
+      sort: filter.sort,
+    });
+  };
+
+  const handleSearchChange = (search: string) => {
+    setFilter((prev) => ({
+      ...prev,
+      search: search || undefined,
+      page: 0,
+    }));
+  };
+
+  // Pagination handlers
+  const handlePageChange = (page: number) => {
+    setFilter((prev) => ({ ...prev, page }));
+  };
+
+  const handlePageSizeChange = (size: number) => {
+    setFilter((prev) => ({ ...prev, size, page: 0 }));
+  };
+
+  // Sort handlers
+  const handleSortChange = (field: SortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+    setFilter((prev) => ({
+      ...prev,
+      sort: `${field},${direction}`,
+      page: 0,
+    }));
+  };
+
+  // Transaction actions
+  const handleAddTransaction = () => {
+    navigate(ROUTES.TRANSACTIONS_NEW);
+  };
+
+  const handleEditTransaction = (transaction: Transaction) => {
+    navigate(`${ROUTES.TRANSACTIONS}/${transaction.id}/edit`);
+  };
+
+  const handleDeleteClick = (transaction: Transaction) => {
+    setDeleteTarget(transaction);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+
+    setDeleting(true);
+    try {
+      await transactionApi.deleteTransaction(deleteTarget.id);
+      setSnackbar({
+        open: true,
+        message: 'Transaction deleted successfully',
+        severity: 'success',
+      });
+      setDeleteTarget(null);
+      fetchTransactions();
+    } catch (err) {
+      setSnackbar({
+        open: true,
+        message: getErrorMessage(err),
+        severity: 'error',
+      });
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleDeleteCancel = () => {
+    setDeleteTarget(null);
+  };
+
+  const handleCloseSnackbar = () => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
+
+  const userInitials = user
+    ? `${user.firstName?.[0] || ''}${user.lastName?.[0] || ''}`.toUpperCase() ||
+      user.email[0].toUpperCase()
+    : '';
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      {/* App Bar */}
+      <AppBar position="static" color="default" elevation={1}>
+        <Toolbar>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              flexGrow: 1,
+              cursor: 'pointer',
+            }}
+            onClick={handleDashboard}
+          >
+            <AccountBalanceWalletIcon sx={{ mr: 1, color: 'primary.main' }} />
+            <Typography variant="h6" component="div" sx={{ fontWeight: 600 }}>
+              Personal Finance
+            </Typography>
+          </Box>
+
+          {/* User Menu */}
+          <IconButton
+            size="large"
+            aria-label="Account menu"
+            aria-controls="menu-appbar"
+            aria-haspopup="true"
+            onClick={handleMenuOpen}
+            color="inherit"
+          >
+            {userInitials ? (
+              <Avatar sx={{ width: 32, height: 32, bgcolor: 'primary.main' }}>
+                {userInitials}
+              </Avatar>
+            ) : (
+              <AccountCircle />
+            )}
+          </IconButton>
+          <Menu
+            id="menu-appbar"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            keepMounted
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={Boolean(anchorEl)}
+            onClose={handleMenuClose}
+          >
+            <MenuItem disabled sx={{ opacity: 1 }}>
+              <Typography variant="body2" color="text.secondary">
+                {user?.email}
+              </Typography>
+            </MenuItem>
+            <MenuItem onClick={handleSettings}>
+              <Settings sx={{ mr: 1, fontSize: 20 }} />
+              Settings
+            </MenuItem>
+            <MenuItem onClick={handleLogout}>
+              <Logout sx={{ mr: 1, fontSize: 20 }} />
+              Logout
+            </MenuItem>
+          </Menu>
+        </Toolbar>
+      </AppBar>
+
+      {/* Main Content */}
+      <Container maxWidth="lg" sx={{ flexGrow: 1, py: 4 }}>
+        {/* Page Header */}
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 3,
+          }}
+        >
+          <Typography variant="h4" component="h1" fontWeight={600}>
+            Transactions
+          </Typography>
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={handleAddTransaction}
+          >
+            Add Transaction
+          </Button>
+        </Box>
+
+        {/* Summary Cards */}
+        <Box sx={{ mb: 3 }}>
+          <TransactionSummary summary={response?.summary || null} loading={loading} />
+        </Box>
+
+        {/* Search and Filters */}
+        <Box sx={{ mb: 3, display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TransactionSearch
+            value={filter.search || ''}
+            onChange={handleSearchChange}
+          />
+          <TransactionFilter
+            filter={filter}
+            onFilterChange={handleFilterChange}
+            onClear={handleClearFilters}
+          />
+        </Box>
+
+        {/* Error Alert */}
+        {error && (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Transaction List */}
+        <TransactionList
+          transactions={response?.content || []}
+          loading={loading}
+          page={filter.page || 0}
+          pageSize={filter.size || DEFAULT_PAGE_SIZE}
+          totalElements={response?.totalElements || 0}
+          sortField={sortField}
+          sortDirection={sortDirection}
+          onPageChange={handlePageChange}
+          onPageSizeChange={handlePageSizeChange}
+          onSortChange={handleSortChange}
+          onEdit={handleEditTransaction}
+          onDelete={handleDeleteClick}
+        />
+      </Container>
+
+      {/* Delete Confirmation Dialog */}
+      <DeleteConfirmDialog
+        open={!!deleteTarget}
+        onClose={handleDeleteCancel}
+        onConfirm={handleDeleteConfirm}
+        loading={deleting}
+      />
+
+      {/* Snackbar for notifications */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbar.severity}
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default TransactionsPage;

--- a/frontend/src/pages/transactions/index.ts
+++ b/frontend/src/pages/transactions/index.ts
@@ -1,0 +1,3 @@
+export { default as TransactionsPage } from './TransactionsPage';
+export { default as CreateTransactionPage } from './CreateTransactionPage';
+export { default as EditTransactionPage } from './EditTransactionPage';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './auth';
+export * from './transaction';

--- a/frontend/src/types/transaction.ts
+++ b/frontend/src/types/transaction.ts
@@ -1,0 +1,221 @@
+/**
+ * Transaction type enum
+ */
+export type TransactionType = 'INCOME' | 'EXPENSE';
+
+/**
+ * Category data returned from the API
+ */
+export interface Category {
+  id: string;
+  name: string;
+  type: TransactionType;
+  icon: string;
+  color: string;
+}
+
+/**
+ * Transaction data returned from the API
+ */
+export interface Transaction {
+  id: string;
+  amount: number;
+  type: TransactionType;
+  category: Category;
+  date: string;
+  description: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Create transaction request payload
+ */
+export interface CreateTransactionRequest {
+  amount: number;
+  type: TransactionType;
+  categoryId: string;
+  date: string;
+  description?: string | null;
+  notes?: string | null;
+}
+
+/**
+ * Update transaction request payload
+ */
+export interface UpdateTransactionRequest {
+  amount: number;
+  type: TransactionType;
+  categoryId: string;
+  date: string;
+  description?: string | null;
+  notes?: string | null;
+}
+
+/**
+ * Transaction list summary
+ */
+export interface TransactionListSummary {
+  totalIncome: number;
+  totalExpenses: number;
+  netBalance: number;
+}
+
+/**
+ * Applied filters in the response
+ */
+export interface AppliedFilters {
+  startDate: string | null;
+  endDate: string | null;
+  type: TransactionType | null;
+  categoryIds: string[];
+  minAmount: number | null;
+  maxAmount: number | null;
+  search: string | null;
+}
+
+/**
+ * Paginated transaction list response
+ */
+export interface TransactionListResponse {
+  content: Transaction[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  last: boolean;
+  summary: TransactionListSummary;
+  appliedFilters?: AppliedFilters;
+}
+
+/**
+ * Transaction filter parameters for API requests
+ */
+export interface TransactionFilter {
+  startDate?: string;
+  endDate?: string;
+  type?: TransactionType;
+  categoryIds?: string[];
+  minAmount?: number;
+  maxAmount?: number;
+  search?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+/**
+ * Categories response grouped by type
+ */
+export interface CategoriesResponse {
+  income: Category[];
+  expense: Category[];
+}
+
+/**
+ * Category summary in breakdown
+ */
+export interface CategorySummary {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+}
+
+/**
+ * Category breakdown item in summary
+ */
+export interface CategoryBreakdownItem {
+  category: CategorySummary;
+  total: number;
+  percentage: number;
+  transactionCount: number;
+}
+
+/**
+ * Category breakdown grouped by type
+ */
+export interface CategoryBreakdown {
+  income: CategoryBreakdownItem[];
+  expense: CategoryBreakdownItem[];
+}
+
+/**
+ * Summary period
+ */
+export interface SummaryPeriod {
+  startDate: string;
+  endDate: string;
+}
+
+/**
+ * Summary totals
+ */
+export interface SummaryTotals {
+  income: number;
+  expenses: number;
+  net: number;
+  transactionCount: number;
+}
+
+/**
+ * Previous period summary
+ */
+export interface PreviousPeriodSummary {
+  startDate: string;
+  endDate: string;
+  income: number;
+  expenses: number;
+  net: number;
+}
+
+/**
+ * Period change percentages
+ */
+export interface PeriodChange {
+  income: string;
+  expenses: string;
+  net: string;
+}
+
+/**
+ * Period comparison
+ */
+export interface PeriodComparison {
+  previousPeriod: PreviousPeriodSummary;
+  change: PeriodChange;
+}
+
+/**
+ * Full transaction summary response
+ */
+export interface TransactionSummaryResponse {
+  period: SummaryPeriod;
+  totals: SummaryTotals;
+  categoryBreakdown: CategoryBreakdown;
+  comparison?: PeriodComparison;
+}
+
+/**
+ * Date range preset options
+ */
+export type DateRangePreset =
+  | 'today'
+  | 'last7days'
+  | 'last30days'
+  | 'thisMonth'
+  | 'lastMonth'
+  | 'thisYear'
+  | 'custom';
+
+/**
+ * Sort direction
+ */
+export type SortDirection = 'asc' | 'desc';
+
+/**
+ * Sortable fields
+ */
+export type SortField = 'date' | 'amount' | 'category' | 'createdAt';


### PR DESCRIPTION
## Summary
Complete implementation of Epic 2: Transactions, enabling users to track income and expenses with full CRUD operations, filtering, search, and summary statistics.

### Features Implemented
- **Create Transaction** - Add income/expense with amount, category, date, description
- **View Transactions** - Paginated list with sorting by date/amount/category  
- **Edit Transaction** - Update any transaction fields
- **Delete Transaction** - Remove with confirmation dialog
- **Filter Transactions** - By date range, type, category, amount range
- **Search Transactions** - Full-text search on description/notes
- **Transaction Categories** - 15 predefined categories (5 income, 10 expense)
- **Pagination & Sorting** - Configurable page size, multi-field sorting
- **Summary Statistics** - Income/expense totals, category breakdowns

## GitHub Issues
Closes #3, Closes #4, Closes #5, Closes #6, Closes #7, Closes #8, Closes #9, Closes #10, Closes #11, Closes #12

## Agent Contributions

| Agent | Deliverable |
|-------|-------------|
| **PM** | User stories with acceptance criteria (`docs/requirements/user-stories/epic-2-transactions.md`) |
| **Architect** | OpenAPI spec and ADR (`docs/api/transaction-endpoints.yaml`, `docs/architecture/adrs/ADR-002-transaction-architecture.md`) |
| **Database** | Flyway migrations, JPA entities, repositories (V4, V5 migrations) |
| **Backend** | Controllers, services, DTOs, specifications, exception handlers |
| **Frontend** | Pages, components, API layer, types, Material-UI integration |
| **QA** | Unit tests, integration tests, E2E tests, coverage documentation |

## Files Changed
- **docs/**: User stories, API spec, ADR, test coverage docs
- **backend/**: Database migrations, entities, repositories, DTOs, services, controllers, tests
- **frontend/**: Types, API layer, components, pages, tests

## Test Plan
- [ ] Backend unit tests pass (`mvn test`)
- [ ] Backend integration tests pass with TestContainers
- [ ] Frontend component tests pass (`npm test`)
- [ ] Manual testing of transaction CRUD
- [ ] Manual testing of filtering and search
- [ ] Manual testing of pagination

## Screenshots
_Add screenshots after running locally_

🤖 Generated with [Claude Code](https://claude.com/claude-code)